### PR TITLE
Fix memory leak and optimize dot rendering

### DIFF
--- a/Mac Motion Cues/Mac_Motion_CuesApp.swift
+++ b/Mac Motion Cues/Mac_Motion_CuesApp.swift
@@ -1,5 +1,4 @@
 import AppKit
-import Combine
 import Sparkle
 import SwiftUI
 

--- a/Mac Motion Cues/Model/Dot.swift
+++ b/Mac Motion Cues/Model/Dot.swift
@@ -7,17 +7,9 @@
 
 import SwiftUI
 
-struct Dot: Identifiable, Animatable {
+struct Dot: Identifiable {
     var id = UUID()
     var offsetY: CGFloat
     var offsetX: CGFloat = 0
     var size: CGFloat
-
-    var animatableData: AnimatablePair<CGFloat, CGFloat> {
-        get { AnimatablePair(offsetX, offsetY) }
-        set {
-            offsetX = newValue.first
-            offsetY = newValue.second
-        }
-    }
 }

--- a/Mac Motion Cues/View/DotsView.swift
+++ b/Mac Motion Cues/View/DotsView.swift
@@ -1,17 +1,15 @@
-import Combine
 import SwiftUI
 
 struct DotsView: View {
     @Bindable var dotsViewModel: DotsViewModel
     @Bindable var motionViewModel: MotionViewModel
 
-    @State private var scrollingCancellable: AnyCancellable?
-
     var body: some View {
         GeometryReader { geometry in
             TimelineView(.animation(minimumInterval: 1 / 30, paused: !motionViewModel.isMotionEnabled)) { context in
                 ZStack {
-                    ForEach(Array(dotsViewModel.dots.enumerated()), id: \.element.id) { index, dot in
+                    ForEach(dotsViewModel.dots.indices, id: \.self) { index in
+                        let dot = dotsViewModel.dots[index]
                         Circle()
                             .fill(.black)
                             .frame(width: dot.size, height: dot.size)
@@ -30,9 +28,6 @@ struct DotsView: View {
                 }
                 .onAppear {
                     dotsViewModel.initializeDots(screenHeight: geometry.size.height)
-                }
-                .onDisappear {
-                    scrollingCancellable?.cancel()
                 }
             }
         }

--- a/Mac Motion Cues/View/DotsView.swift
+++ b/Mac Motion Cues/View/DotsView.swift
@@ -29,6 +29,9 @@ struct DotsView: View {
                 .onAppear {
                     dotsViewModel.initializeDots(screenHeight: geometry.size.height)
                 }
+                .onDisappear {
+                    motionViewModel.stopDeviceMotion()
+                }
             }
         }
     }

--- a/Mac Motion Cues/View/DotsView.swift
+++ b/Mac Motion Cues/View/DotsView.swift
@@ -23,8 +23,6 @@ struct DotsView: View {
                             )
                             .opacity(dot.offsetY < dotsViewModel.dotSize ||
                                 dot.offsetY > geometry.size.height - 150 ? 0 : 1)
-                            .animation(.easeInOut(duration: 0.06), value: dot.offsetY)
-                            .animation(.easeInOut(duration: 0.06), value: dot.offsetX)
                     }
                 }
                 .onChange(of: context.date) {

--- a/Mac Motion Cues/ViewModel/DotsViewModel.swift
+++ b/Mac Motion Cues/ViewModel/DotsViewModel.swift
@@ -1,4 +1,3 @@
-import Combine
 import Foundation
 import SwiftUI
 
@@ -21,8 +20,6 @@ class DotsViewModel {
     private var screenWidth: CGFloat = 800
 
     private var lastUpdateTime: TimeInterval = CACurrentMediaTime()
-
-    private var cancellables = Set<AnyCancellable>()
 
     init() {}
 
@@ -58,36 +55,37 @@ class DotsViewModel {
     }
 
     func updateSpacing() {
-        dots = stride(from: 0, through: screenHeight, by: verticalSpacing).map { y in
-            let existingDot = dots.first {
-                abs($0.offsetY - (screenHeight - y)) < verticalSpacing / 2
-            }
+        let positions = Array(stride(from: 0, through: screenHeight, by: verticalSpacing))
+        let targetCount = positions.count
 
-            return Dot(
-                offsetY: screenHeight - y,
-                offsetX: existingDot?.offsetX ?? 0,
-                size: dotSize
-            )
+        // Reuse existing dots (preserving identity) and adjust count as needed
+        while dots.count > targetCount {
+            dots.removeLast()
+        }
+        while dots.count < targetCount {
+            dots.append(Dot(offsetY: 0, offsetX: 0, size: dotSize))
+        }
+
+        for (i, y) in positions.enumerated() {
+            dots[i].offsetY = screenHeight - y
+            dots[i].size = dotSize
         }
     }
 
     func updateDotsPosition() {
-        if !MotionViewModel.shared.isMotionEnabled {
-            return
-        }
         guard MotionViewModel.shared.isMotionEnabled else { return }
 
         let fixedDeltaTime: CGFloat = 1.0 / 60.0
 
         let motionX = CGFloat(MotionViewModel.shared.motionX)
+        let motionY = CGFloat(MotionViewModel.shared.motionY)
 
         let isXMotionRelevant = abs(motionX) > 0.02
-
-        let motionY = CGFloat(MotionViewModel.shared.motionY)
+        let isYMotionRelevant = abs(motionY) > 0.02
 
         var baseSpeedY: CGFloat = 0
         var xInfluence: CGFloat = 0
-        let isYMotionRelevant = abs(motionY) > 0.02
+
         if isYMotionRelevant {
             baseSpeedY = 200 * fixedDeltaTime * motionY * motionSensitivity
         }
@@ -97,6 +95,14 @@ class DotsViewModel {
         }
 
         let boundWidth = rightBound - leftBound
+
+        // Pre-compute min/max Y once before the loop instead of per-wrapping-dot
+        var maxY = -CGFloat.greatestFiniteMagnitude
+        var minY = CGFloat.greatestFiniteMagnitude
+        for dot in dots {
+            if dot.offsetY > maxY { maxY = dot.offsetY }
+            if dot.offsetY < minY { minY = dot.offsetY }
+        }
 
         for index in dots.indices {
             if isXMotionRelevant {
@@ -113,17 +119,9 @@ class DotsViewModel {
                 dots[index].offsetY -= baseSpeedY
 
                 if dots[index].offsetY <= -dotSize {
-                    if let lowestDotY = dots.max(by: { $0.offsetY < $1.offsetY })?.offsetY {
-                        dots[index].offsetY = lowestDotY + verticalSpacing
-                    } else {
-                        dots[index].offsetY = screenHeight + verticalSpacing
-                    }
+                    dots[index].offsetY = maxY + verticalSpacing
                 } else if dots[index].offsetY > screenHeight + verticalSpacing {
-                    if let highestDotY = dots.min(by: { $0.offsetY < $1.offsetY })?.offsetY {
-                        dots[index].offsetY = highestDotY - verticalSpacing
-                    } else {
-                        dots[index].offsetY = -dotSize
-                    }
+                    dots[index].offsetY = minY - verticalSpacing
                 }
             }
         }

--- a/Mac Motion Cues/ViewModel/MotionViewModel.swift
+++ b/Mac Motion Cues/ViewModel/MotionViewModel.swift
@@ -1,4 +1,3 @@
-import Combine
 import CoreMotion
 
 @Observable
@@ -13,8 +12,6 @@ class MotionViewModel {
     
     private var motion = CMHeadphoneMotionManager()
     private var motionQueue = OperationQueue()
-    private var cancellables = Set<AnyCancellable>()
-    
     init() {
         motionQueue.name = "MotionQueue"
         motionQueue.qualityOfService = .userInteractive
@@ -50,6 +47,5 @@ class MotionViewModel {
     
     deinit {
         stopDeviceMotion()
-        cancellables.forEach { $0.cancel() }
     }
 }


### PR DESCRIPTION
## Summary
- **Fix memory leak** caused by overlapping SwiftUI animation modifiers competing with the TimelineView game loop, creating unbounded internal animation state
- **Eliminate per-frame array allocations** in DotsView's ForEach by iterating indices directly
- **Stop motion updates** when DotsView disappears to prevent orphaned CoreMotion callbacks
- **Optimize dot position updates** with pre-computed min/max Y and preserve dot identity on spacing changes
- **Remove unused Combine imports** and cancellables across multiple files

## Test plan
- [ ] Launch app and connect AirPods
- [ ] Enable motion cues and verify dots animate smoothly
- [ ] Monitor memory usage in Activity Monitor — should remain stable over time
- [ ] Toggle app on/off multiple times and verify no memory growth
- [ ] Adjust dot size and spacing sliders — dots should update without flickering
- [ ] Disconnect AirPods and verify motion updates stop cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)