### PR TITLE
Oberbeck

### DIFF
--- a/Mac Motion Cues.xcodeproj/project.pbxproj
+++ b/Mac Motion Cues.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		079905422DA8658A0029D42F /* UpdateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079905412DA865880029D42F /* UpdateView.swift */; };
 		0799FE012E0000000029D42F /* OverlayWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0799FE022E0000000029D42F /* OverlayWindowController.swift */; };
 		0799FE032E0000000029D42F /* DotsSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0799FE042E0000000029D42F /* DotsSettings.swift */; };
+		0799FE052E0000000029D42F /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0799FE062E0000000029D42F /* AppState.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -42,6 +43,7 @@
 		079905412DA865880029D42F /* UpdateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateView.swift; sourceTree = "<group>"; };
 		0799FE022E0000000029D42F /* OverlayWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayWindowController.swift; sourceTree = "<group>"; };
 		0799FE042E0000000029D42F /* DotsSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DotsSettings.swift; sourceTree = "<group>"; };
+		0799FE062E0000000029D42F /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		07AEFBDD2CF00D44001A9095 /* Mac Motion Cues.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Mac Motion Cues.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -90,6 +92,7 @@
 				079905272DA860F00029D42F /* DotsViewModel.swift */,
 				079905282DA860F00029D42F /* MotionViewModel.swift */,
 				0799FE042E0000000029D42F /* DotsSettings.swift */,
+				0799FE062E0000000029D42F /* AppState.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -229,6 +232,7 @@
 				079905342DA860F00029D42F /* Mac_Motion_CuesApp.swift in Sources */,
 				0799FE012E0000000029D42F /* OverlayWindowController.swift in Sources */,
 				0799FE032E0000000029D42F /* DotsSettings.swift in Sources */,
+				0799FE052E0000000029D42F /* AppState.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Mac Motion Cues.xcodeproj/project.pbxproj
+++ b/Mac Motion Cues.xcodeproj/project.pbxproj
@@ -13,7 +13,6 @@
 		079905302DA860F00029D42F /* DotsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079905242DA860F00029D42F /* DotsView.swift */; };
 		079905312DA860F00029D42F /* MenuBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079905252DA860F00029D42F /* MenuBar.swift */; };
 		079905322DA860F00029D42F /* DotsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079905272DA860F00029D42F /* DotsViewModel.swift */; };
-		079905332DA860F00029D42F /* MotionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079905282DA860F00029D42F /* MotionViewModel.swift */; };
 		079905342DA860F00029D42F /* Mac_Motion_CuesApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0799052D2DA860F00029D42F /* Mac_Motion_CuesApp.swift */; };
 		079905352DA860F00029D42F /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 079905222DA860F00029D42F /* Preview Assets.xcassets */; };
 		079905362DA860F00029D42F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0799052A2DA860F00029D42F /* Assets.xcassets */; };
@@ -24,6 +23,10 @@
 		0799FE012E0000000029D42F /* OverlayWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0799FE022E0000000029D42F /* OverlayWindowController.swift */; };
 		0799FE032E0000000029D42F /* DotsSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0799FE042E0000000029D42F /* DotsSettings.swift */; };
 		0799FE052E0000000029D42F /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0799FE062E0000000029D42F /* AppState.swift */; };
+		0799FE072E0000000029D42F /* MotionSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0799FE082E0000000029D42F /* MotionSource.swift */; };
+		0799FE092E0000000029D42F /* AirPodsMotionSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0799FE0A2E0000000029D42F /* AirPodsMotionSource.swift */; };
+		0799FE0C2E0000000029D42F /* MotionPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0799FE0D2E0000000029D42F /* MotionPipeline.swift */; };
+		0799FE0E2E0000000029D42F /* CoreLocationDetectionSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0799FE0F2E0000000029D42F /* CoreLocationDetectionSource.swift */; };
 		7C06465E2FAB608C000B6D48 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 7C06465D2FAB608C000B6D48 /* InfoPlist.xcstrings */; };
 /* End PBXBuildFile section */
 
@@ -34,7 +37,6 @@
 		079905242DA860F00029D42F /* DotsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DotsView.swift; sourceTree = "<group>"; };
 		079905252DA860F00029D42F /* MenuBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBar.swift; sourceTree = "<group>"; };
 		079905272DA860F00029D42F /* DotsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DotsViewModel.swift; sourceTree = "<group>"; };
-		079905282DA860F00029D42F /* MotionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MotionViewModel.swift; sourceTree = "<group>"; };
 		0799052A2DA860F00029D42F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		0799052B2DA860F00029D42F /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		0799052C2DA860F00029D42F /* Mac_Motion_Cues.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Mac_Motion_Cues.entitlements; sourceTree = "<group>"; };
@@ -45,6 +47,10 @@
 		0799FE022E0000000029D42F /* OverlayWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayWindowController.swift; sourceTree = "<group>"; };
 		0799FE042E0000000029D42F /* DotsSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DotsSettings.swift; sourceTree = "<group>"; };
 		0799FE062E0000000029D42F /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
+		0799FE082E0000000029D42F /* MotionSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MotionSource.swift; sourceTree = "<group>"; };
+		0799FE0A2E0000000029D42F /* AirPodsMotionSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirPodsMotionSource.swift; sourceTree = "<group>"; };
+		0799FE0D2E0000000029D42F /* MotionPipeline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MotionPipeline.swift; sourceTree = "<group>"; };
+		0799FE0F2E0000000029D42F /* CoreLocationDetectionSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreLocationDetectionSource.swift; sourceTree = "<group>"; };
 		07AEFBDD2CF00D44001A9095 /* Mac Motion Cues.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Mac Motion Cues.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7C06465D2FAB608C000B6D48 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -92,11 +98,21 @@
 			isa = PBXGroup;
 			children = (
 				079905272DA860F00029D42F /* DotsViewModel.swift */,
-				079905282DA860F00029D42F /* MotionViewModel.swift */,
 				0799FE042E0000000029D42F /* DotsSettings.swift */,
 				0799FE062E0000000029D42F /* AppState.swift */,
 			);
 			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		0799FE0B2E0000000029D42F /* Motion */ = {
+			isa = PBXGroup;
+			children = (
+				0799FE082E0000000029D42F /* MotionSource.swift */,
+				0799FE0A2E0000000029D42F /* AirPodsMotionSource.swift */,
+				0799FE0F2E0000000029D42F /* CoreLocationDetectionSource.swift */,
+				0799FE0D2E0000000029D42F /* MotionPipeline.swift */,
+			);
+			path = Motion;
 			sourceTree = "<group>";
 		};
 		0799052E2DA860F00029D42F /* Mac Motion Cues */ = {
@@ -108,6 +124,7 @@
 				079905232DA860F00029D42F /* Preview Content */,
 				079905262DA860F00029D42F /* View */,
 				079905292DA860F00029D42F /* ViewModel */,
+				0799FE0B2E0000000029D42F /* Motion */,
 				0799052A2DA860F00029D42F /* Assets.xcassets */,
 				0799052B2DA860F00029D42F /* Localizable.xcstrings */,
 				0799052C2DA860F00029D42F /* Mac_Motion_Cues.entitlements */,
@@ -232,11 +249,14 @@
 				079905312DA860F00029D42F /* MenuBar.swift in Sources */,
 				0799053A2DA860FE0029D42F /* SparkleUpdater.swift in Sources */,
 				079905322DA860F00029D42F /* DotsViewModel.swift in Sources */,
-				079905332DA860F00029D42F /* MotionViewModel.swift in Sources */,
 				079905342DA860F00029D42F /* Mac_Motion_CuesApp.swift in Sources */,
 				0799FE012E0000000029D42F /* OverlayWindowController.swift in Sources */,
 				0799FE032E0000000029D42F /* DotsSettings.swift in Sources */,
 				0799FE052E0000000029D42F /* AppState.swift in Sources */,
+				0799FE072E0000000029D42F /* MotionSource.swift in Sources */,
+				0799FE092E0000000029D42F /* AirPodsMotionSource.swift in Sources */,
+				0799FE0C2E0000000029D42F /* MotionPipeline.swift in Sources */,
+				0799FE0E2E0000000029D42F /* CoreLocationDetectionSource.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -382,11 +402,8 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Mac-Motion-Cues-Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "Mac Motion Cues";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_LSUIElement = YES;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				INFOPLIST_KEY_NSMotionUsageDescription = "This app uses device motion to better calculate motion cues";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",

--- a/Mac Motion Cues.xcodeproj/project.pbxproj
+++ b/Mac Motion Cues.xcodeproj/project.pbxproj
@@ -205,6 +205,7 @@
 			knownRegions = (
 				en,
 				Base,
+				de,
 				"pt-BR",
 			);
 			mainGroup = 07AEFBD42CF00D44001A9095;

--- a/Mac Motion Cues.xcodeproj/project.pbxproj
+++ b/Mac Motion Cues.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		0799FE012E0000000029D42F /* OverlayWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0799FE022E0000000029D42F /* OverlayWindowController.swift */; };
 		0799FE032E0000000029D42F /* DotsSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0799FE042E0000000029D42F /* DotsSettings.swift */; };
 		0799FE052E0000000029D42F /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0799FE062E0000000029D42F /* AppState.swift */; };
+		7C06465E2FAB608C000B6D48 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 7C06465D2FAB608C000B6D48 /* InfoPlist.xcstrings */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -45,6 +46,7 @@
 		0799FE042E0000000029D42F /* DotsSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DotsSettings.swift; sourceTree = "<group>"; };
 		0799FE062E0000000029D42F /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		07AEFBDD2CF00D44001A9095 /* Mac Motion Cues.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Mac Motion Cues.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7C06465D2FAB608C000B6D48 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -110,6 +112,7 @@
 				0799052B2DA860F00029D42F /* Localizable.xcstrings */,
 				0799052C2DA860F00029D42F /* Mac_Motion_Cues.entitlements */,
 				0799052D2DA860F00029D42F /* Mac_Motion_CuesApp.swift */,
+				7C06465D2FAB608C000B6D48 /* InfoPlist.xcstrings */,
 			);
 			path = "Mac Motion Cues";
 			sourceTree = "<group>";
@@ -209,6 +212,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				079905352DA860F00029D42F /* Preview Assets.xcassets in Resources */,
+				7C06465E2FAB608C000B6D48 /* InfoPlist.xcstrings in Resources */,
 				079905362DA860F00029D42F /* Assets.xcassets in Resources */,
 				079905372DA860F00029D42F /* Localizable.xcstrings in Resources */,
 				0799051D2DA85F6B0029D42F /* Localizable.xcstrings in Resources */,

--- a/Mac Motion Cues.xcodeproj/project.pbxproj
+++ b/Mac Motion Cues.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		0799053A2DA860FE0029D42F /* SparkleUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079905392DA860FA0029D42F /* SparkleUpdater.swift */; };
 		0799053E2DA862BB0029D42F /* LaunchAtLogin in Frameworks */ = {isa = PBXBuildFile; productRef = 0799053D2DA862BB0029D42F /* LaunchAtLogin */; };
 		079905422DA8658A0029D42F /* UpdateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079905412DA865880029D42F /* UpdateView.swift */; };
+		0799FE012E0000000029D42F /* OverlayWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0799FE022E0000000029D42F /* OverlayWindowController.swift */; };
+		0799FE032E0000000029D42F /* DotsSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0799FE042E0000000029D42F /* DotsSettings.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -38,6 +40,8 @@
 		079905392DA860FA0029D42F /* SparkleUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleUpdater.swift; sourceTree = "<group>"; };
 		0799053B2DA8620D0029D42F /* Mac-Motion-Cues-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "Mac-Motion-Cues-Info.plist"; sourceTree = SOURCE_ROOT; };
 		079905412DA865880029D42F /* UpdateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateView.swift; sourceTree = "<group>"; };
+		0799FE022E0000000029D42F /* OverlayWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayWindowController.swift; sourceTree = "<group>"; };
+		0799FE042E0000000029D42F /* DotsSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DotsSettings.swift; sourceTree = "<group>"; };
 		07AEFBDD2CF00D44001A9095 /* Mac Motion Cues.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Mac Motion Cues.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -75,6 +79,7 @@
 			children = (
 				079905242DA860F00029D42F /* DotsView.swift */,
 				079905252DA860F00029D42F /* MenuBar.swift */,
+				0799FE022E0000000029D42F /* OverlayWindowController.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -84,6 +89,7 @@
 			children = (
 				079905272DA860F00029D42F /* DotsViewModel.swift */,
 				079905282DA860F00029D42F /* MotionViewModel.swift */,
+				0799FE042E0000000029D42F /* DotsSettings.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -221,6 +227,8 @@
 				079905322DA860F00029D42F /* DotsViewModel.swift in Sources */,
 				079905332DA860F00029D42F /* MotionViewModel.swift in Sources */,
 				079905342DA860F00029D42F /* Mac_Motion_CuesApp.swift in Sources */,
+				0799FE012E0000000029D42F /* OverlayWindowController.swift in Sources */,
+				0799FE032E0000000029D42F /* DotsSettings.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Mac Motion Cues/InfoPlist.xcstrings
+++ b/Mac Motion Cues/InfoPlist.xcstrings
@@ -43,6 +43,12 @@
       "comment" : "Privacy - Location Usage Description",
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wird verwendet, um Bewegungshinweise automatisch zu aktivieren, wenn du dich in einem fahrenden Fahrzeug befindest."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -61,6 +67,12 @@
       "comment" : "Privacy - Location When In Use Usage Description",
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wird verwendet, um Bewegungshinweise automatisch zu aktivieren, wenn du dich in einem fahrenden Fahrzeug befindest."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -78,6 +90,12 @@
     "NSMotionUsageDescription" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diese App nutzt die Gerätebewegung, um Bewegungshinweise zu berechnen."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/Mac Motion Cues/InfoPlist.xcstrings
+++ b/Mac Motion Cues/InfoPlist.xcstrings
@@ -1,0 +1,62 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "CFBundleDisplayName" : {
+      "comment" : "Bundle display name",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mac Motion Cues"
+          }
+        }
+      },
+      "shouldTranslate" : false
+    },
+    "CFBundleName" : {
+      "comment" : "Bundle name",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mac Motion Cues"
+          }
+        }
+      },
+      "shouldTranslate" : false
+    },
+    "NSHumanReadableCopyright" : {
+      "comment" : "Copyright (human-readable)",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        }
+      },
+      "shouldTranslate" : false
+    },
+    "NSMotionUsageDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This app uses device motion to calculate motion cues"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este app usa o movimento do dispositivo para calcular os indicadores de movimento."
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/Mac Motion Cues/InfoPlist.xcstrings
+++ b/Mac Motion Cues/InfoPlist.xcstrings
@@ -3,7 +3,7 @@
   "strings" : {
     "CFBundleDisplayName" : {
       "comment" : "Bundle display name",
-      "extractionState" : "extracted_with_value",
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -16,7 +16,6 @@
     },
     "CFBundleName" : {
       "comment" : "Bundle name",
-      "extractionState" : "extracted_with_value",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -29,7 +28,7 @@
     },
     "NSHumanReadableCopyright" : {
       "comment" : "Copyright (human-readable)",
-      "extractionState" : "extracted_with_value",
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -39,6 +38,42 @@
         }
       },
       "shouldTranslate" : false
+    },
+    "NSLocationUsageDescription" : {
+      "comment" : "Privacy - Location Usage Description",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Used to auto-enable motion cues when you're in a moving vehicle."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usado para ativar automaticamente os indicadores de movimento quando você está em um veículo em movimento."
+          }
+        }
+      }
+    },
+    "NSLocationWhenInUseUsageDescription" : {
+      "comment" : "Privacy - Location When In Use Usage Description",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Used to auto-enable motion cues when you're in a moving vehicle."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usado para ativar automaticamente os indicadores de movimento quando você está em um veículo em movimento."
+          }
+        }
+      }
     },
     "NSMotionUsageDescription" : {
       "extractionState" : "manual",

--- a/Mac Motion Cues/Localizable.xcstrings
+++ b/Mac Motion Cues/Localizable.xcstrings
@@ -221,9 +221,6 @@
         }
       }
     },
-    "Style" : {
-
-    },
     "View Source Code" : {
       "localizations" : {
         "pt-BR" : {
@@ -244,7 +241,11 @@
         }
       }
     },
+    "X:" : {
+
+    },
     "X: %@" : {
+      "extractionState" : "stale",
       "localizations" : {
         "pt-BR" : {
           "stringUnit" : {
@@ -254,7 +255,11 @@
         }
       }
     },
+    "Y:" : {
+
+    },
     "Y: %@" : {
+      "extractionState" : "stale",
       "localizations" : {
         "pt-BR" : {
           "stringUnit" : {

--- a/Mac Motion Cues/Localizable.xcstrings
+++ b/Mac Motion Cues/Localizable.xcstrings
@@ -21,6 +21,17 @@
         }
       }
     },
+    "AirPods" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AirPods"
+          }
+        }
+      }
+    },
     "AirPods connected" : {
       "localizations" : {
         "pt-BR" : {
@@ -37,6 +48,26 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "AirPods entraram em modo de espera"
+          }
+        }
+      }
+    },
+    "Asking for location permission…" : {
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solicitando permissão de localização…"
+          }
+        }
+      }
+    },
+    "Auto-enable when in vehicle" : {
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ativar automaticamente em veículos"
           }
         }
       }
@@ -131,12 +162,43 @@
         }
       }
     },
+    "In vehicle" : {
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Em veículo"
+          }
+        }
+      }
+    },
     "Launch at Login" : {
       "localizations" : {
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Abrir ao Iniciar"
+          }
+        }
+      }
+    },
+    "Location access denied" : {
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acesso à localização negado"
+          }
+        }
+      }
+    },
+    "Location services" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Serviços de localização"
           }
         }
       }
@@ -162,6 +224,7 @@
       }
     },
     "Mac Motion Cues uses AirPods head-tracking to drive cue motion." : {
+      "extractionState" : "stale",
       "localizations" : {
         "pt-BR" : {
           "stringUnit" : {
@@ -232,6 +295,7 @@
       }
     },
     "Put on your AirPods" : {
+      "extractionState" : "stale",
       "localizations" : {
         "pt-BR" : {
           "stringUnit" : {
@@ -257,6 +321,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sensibilidade"
+          }
+        }
+      }
+    },
+    "Setting up…" : {
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configurando…"
           }
         }
       }
@@ -291,12 +365,32 @@
         }
       }
     },
+    "Stationary" : {
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parado"
+          }
+        }
+      }
+    },
     "Style" : {
       "localizations" : {
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Estilo"
+          }
+        }
+      }
+    },
+    "Uses AirPods head-tracking to drive cue motion." : {
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usa o rastreamento de movimento dos AirPods para gerar os indicadores."
           }
         }
       }

--- a/Mac Motion Cues/Localizable.xcstrings
+++ b/Mac Motion Cues/Localizable.xcstrings
@@ -3,6 +3,12 @@
   "strings" : {
     "%lld" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13,6 +19,12 @@
     },
     "About" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Über"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -24,6 +36,12 @@
     "AirPods" : {
       "extractionState" : "stale",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AirPods"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -34,6 +52,12 @@
     },
     "AirPods connected" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AirPods verbunden"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -44,6 +68,12 @@
     },
     "AirPods went to sleep" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AirPods im Ruhezustand"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -54,6 +84,12 @@
     },
     "Asking for location permission…" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Standortberechtigung wird angefordert…"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -64,6 +100,12 @@
     },
     "Auto-enable when in vehicle" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Im Fahrzeug automatisch aktivieren"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -74,6 +116,12 @@
     },
     "Check for Updates…" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nach Updates suchen…"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -84,6 +132,12 @@
     },
     "Connecting…" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verbinde…"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -94,6 +148,12 @@
     },
     "Cues need Motion & Fitness to read AirPods movement." : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bewegungshinweise benötigen „Bewegung & Fitness“, um die AirPods-Bewegung zu lesen."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -104,6 +164,12 @@
     },
     "Dot Style" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Punktstil"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -114,6 +180,12 @@
     },
     "Dynamic" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dynamisch"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -124,6 +196,12 @@
     },
     "Enable Visual Cues" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Visuelle Hinweise aktivieren"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -134,6 +212,12 @@
     },
     "Enable X Motion (BETA)" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "X-Bewegung aktivieren (BETA)"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -144,6 +228,12 @@
     },
     "Grant Motion Access" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bewegungszugriff erlauben"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -154,6 +244,12 @@
     },
     "Halo" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Halo"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -164,6 +260,12 @@
     },
     "In vehicle" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Im Fahrzeug"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -174,6 +276,12 @@
     },
     "Launch at Login" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beim Anmelden öffnen"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -184,6 +292,12 @@
     },
     "Location access denied" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Standortzugriff verweigert"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -195,6 +309,12 @@
     "Location services" : {
       "extractionState" : "stale",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ortungsdienste"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -205,6 +325,12 @@
     },
     "Looking for compatible AirPods…" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suche nach kompatiblen AirPods…"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -215,6 +341,12 @@
     },
     "Mac Motion Cues" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mac Motion Cues"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -226,6 +358,12 @@
     "Mac Motion Cues uses AirPods head-tracking to drive cue motion." : {
       "extractionState" : "stale",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mac Motion Cues nutzt die Kopfverfolgung der AirPods, um die Bewegung der Hinweise zu steuern."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -236,6 +374,12 @@
     },
     "Motion access denied" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bewegungszugriff verweigert"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -246,6 +390,12 @@
     },
     "Motion Cues" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bewegungshinweise"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -256,6 +406,12 @@
     },
     "Motion Settings" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bewegungseinstellungen"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -266,6 +422,12 @@
     },
     "Move your head or take them out and put them back in to reconnect." : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bewege deinen Kopf oder nimm die AirPods kurz heraus und setze sie wieder ein, um die Verbindung wiederherzustellen."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -276,6 +438,12 @@
     },
     "Off" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aus"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -286,6 +454,12 @@
     },
     "Open System Settings…" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Systemeinstellungen öffnen…"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -297,6 +471,12 @@
     "Put on your AirPods" : {
       "extractionState" : "stale",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Setze deine AirPods auf"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -307,6 +487,12 @@
     },
     "Quit Mac Motion Cues" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mac Motion Cues beenden"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -317,6 +503,12 @@
     },
     "Sensitivity" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Empfindlichkeit"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -327,6 +519,12 @@
     },
     "Setting up…" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wird eingerichtet…"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -337,6 +535,12 @@
     },
     "Size" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Größe"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -347,6 +551,12 @@
     },
     "Solid" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solide"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -357,6 +567,12 @@
     },
     "Spacing" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abstand"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -367,6 +583,12 @@
     },
     "Stationary" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stationär"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -377,6 +599,12 @@
     },
     "Style" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stil"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -387,6 +615,12 @@
     },
     "Uses AirPods head-tracking to drive cue motion." : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nutzt die Kopfverfolgung der AirPods, um die Bewegung der Hinweise zu steuern."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -397,6 +631,12 @@
     },
     "View Source Code" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quellcode anzeigen"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -407,6 +647,12 @@
     },
     "Visual Settings" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Visuelle Einstellungen"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -423,6 +669,12 @@
     },
     "You may need to relaunch the app after granting access." : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Du musst die App eventuell neu starten, nachdem du den Zugriff erteilt hast."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",

--- a/Mac Motion Cues/Localizable.xcstrings
+++ b/Mac Motion Cues/Localizable.xcstrings
@@ -71,17 +71,6 @@
         }
       }
     },
-    "Disable Motion" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desabilitar Movimento"
-          }
-        }
-      }
-    },
     "Dot Style" : {
       "localizations" : {
         "pt-BR" : {
@@ -98,17 +87,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dinâmico"
-          }
-        }
-      }
-    },
-    "Enable Motion" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Habilitar Movimento"
           }
         }
       }
@@ -344,32 +322,10 @@
       }
     },
     "X:" : {
-
-    },
-    "X: %@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "X: %@"
-          }
-        }
-      }
+      "shouldTranslate" : false
     },
     "Y:" : {
-
-    },
-    "Y: %@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Y: %@"
-          }
-        }
-      }
+      "shouldTranslate" : false
     },
     "You may need to relaunch the app after granting access." : {
       "localizations" : {

--- a/Mac Motion Cues/Localizable.xcstrings
+++ b/Mac Motion Cues/Localizable.xcstrings
@@ -51,6 +51,26 @@
         }
       }
     },
+    "Dot Style" : {
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estilo do Ponto"
+          }
+        }
+      }
+    },
+    "Dynamic" : {
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dinâmico"
+          }
+        }
+      }
+    },
     "Enable Motion" : {
       "localizations" : {
         "pt-BR" : {
@@ -77,6 +97,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Habilitar Movimento Horizontal (BETA)"
+          }
+        }
+      }
+    },
+    "Halo" : {
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Halo"
           }
         }
       }
@@ -121,6 +151,16 @@
         }
       }
     },
+    "Off" : {
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desligado"
+          }
+        }
+      }
+    },
     "Quit Mac Motion Cues" : {
       "localizations" : {
         "pt-BR" : {
@@ -151,6 +191,16 @@
         }
       }
     },
+    "Solid" : {
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sólido"
+          }
+        }
+      }
+    },
     "Spacing" : {
       "localizations" : {
         "pt-BR" : {
@@ -160,6 +210,19 @@
           }
         }
       }
+    },
+    "Style" : {
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estilo"
+          }
+        }
+      }
+    },
+    "Style" : {
+
     },
     "View Source Code" : {
       "localizations" : {

--- a/Mac Motion Cues/Localizable.xcstrings
+++ b/Mac Motion Cues/Localizable.xcstrings
@@ -31,6 +31,16 @@
         }
       }
     },
+    "AirPods went to sleep" : {
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AirPods entraram em modo de espera"
+          }
+        }
+      }
+    },
     "Check for Updates…" : {
       "localizations" : {
         "pt-BR" : {
@@ -41,7 +51,28 @@
         }
       }
     },
+    "Connecting…" : {
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conectando…"
+          }
+        }
+      }
+    },
+    "Cues need Motion & Fitness to read AirPods movement." : {
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Os indicadores precisam de Movimento e Forma Física para ler o movimento dos AirPods."
+          }
+        }
+      }
+    },
     "Disable Motion" : {
+      "extractionState" : "stale",
       "localizations" : {
         "pt-BR" : {
           "stringUnit" : {
@@ -72,6 +103,7 @@
       }
     },
     "Enable Motion" : {
+      "extractionState" : "stale",
       "localizations" : {
         "pt-BR" : {
           "stringUnit" : {
@@ -101,6 +133,16 @@
         }
       }
     },
+    "Grant Motion Access" : {
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conceder Acesso a Movimento"
+          }
+        }
+      }
+    },
     "Halo" : {
       "localizations" : {
         "pt-BR" : {
@@ -121,12 +163,42 @@
         }
       }
     },
+    "Looking for compatible AirPods…" : {
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Procurando AirPods compatíveis…"
+          }
+        }
+      }
+    },
     "Mac Motion Cues" : {
       "localizations" : {
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mac Motion Cues"
+          }
+        }
+      }
+    },
+    "Mac Motion Cues uses AirPods head-tracking to drive cue motion." : {
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O Mac Motion Cues usa o rastreamento de movimento da cabeça dos AirPods para gerar os indicadores."
+          }
+        }
+      }
+    },
+    "Motion access denied" : {
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acesso a movimento negado"
           }
         }
       }
@@ -151,12 +223,42 @@
         }
       }
     },
+    "Move your head or take them out and put them back in to reconnect." : {
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mexa a cabeça ou tire e recoloque os AirPods para reconectar."
+          }
+        }
+      }
+    },
     "Off" : {
       "localizations" : {
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Desligado"
+          }
+        }
+      }
+    },
+    "Open System Settings…" : {
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir Ajustes do Sistema…"
+          }
+        }
+      }
+    },
+    "Put on your AirPods" : {
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coloque seus AirPods"
           }
         }
       }
@@ -265,6 +367,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Y: %@"
+          }
+        }
+      }
+    },
+    "You may need to relaunch the app after granting access." : {
+      "localizations" : {
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Talvez seja necessário reabrir o app após conceder o acesso."
           }
         }
       }

--- a/Mac Motion Cues/Mac_Motion_Cues.entitlements
+++ b/Mac Motion Cues/Mac_Motion_Cues.entitlements
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.personal-information.location</key>
+	<true/>
+</dict>
 </plist>

--- a/Mac Motion Cues/Mac_Motion_CuesApp.swift
+++ b/Mac Motion Cues/Mac_Motion_CuesApp.swift
@@ -4,10 +4,10 @@ import SwiftUI
 
 @main
 struct MacMotionCuesApp: App {
-    var motionViewModel = MotionViewModel.shared
+    private let motionViewModel = MotionViewModel.shared
+    private let appState = AppState.shared
+    private let overlay = OverlayWindowController()
     private let updaterController: SPUStandardUpdaterController
-    @State private var overlay = OverlayWindowController()
-    @AppStorage("appEnabled") private var appEnabled: Bool = true
 
     init() {
         updaterController = SPUStandardUpdaterController(
@@ -15,33 +15,27 @@ struct MacMotionCuesApp: App {
             updaterDelegate: nil,
             userDriverDelegate: nil
         )
+        // Defer to the next runloop tick so NSApp is fully up before we
+        // touch the headphone motion manager or create overlay windows.
+        DispatchQueue.main.async { [motionViewModel, overlay, appState] in
+            motionViewModel.bootstrap()
+            overlay.startObservingMountConditions(
+                appState: appState,
+                motionViewModel: motionViewModel
+            )
+        }
     }
 
     var body: some Scene {
         MenuBarExtra("Motion Cues", systemImage: "cursorarrow.motionlines.click") {
             MenuBar(
                 motionViewModel: motionViewModel,
+                appState: appState,
                 settings: DotsSettings.shared
             )
-            .task { syncOverlayMounting() }
-            .onChange(of: appEnabled) { _, newValue in
-                if !newValue && motionViewModel.isMotionEnabled {
-                    motionViewModel.stopDeviceMotion()
-                }
-                syncOverlayMounting()
-            }
-            .onChange(of: motionViewModel.isMotionEnabled) { syncOverlayMounting() }
         }
         .menuBarExtraStyle(.window)
 
         Settings { EmptyView() }
-    }
-
-    private func syncOverlayMounting() {
-        if appEnabled && motionViewModel.isMotionEnabled {
-            overlay.install()
-        } else {
-            overlay.uninstall()
-        }
     }
 }

--- a/Mac Motion Cues/Mac_Motion_CuesApp.swift
+++ b/Mac Motion Cues/Mac_Motion_CuesApp.swift
@@ -21,28 +21,27 @@ struct MacMotionCuesApp: App {
         MenuBarExtra("Motion Cues", systemImage: "cursorarrow.motionlines.click") {
             MenuBar(
                 motionViewModel: motionViewModel,
-                settings: DotsSettings.shared,
-                overlay: overlay
+                settings: DotsSettings.shared
             )
-            .task { syncOverlay() }
-            .onChange(of: appEnabled) { syncOverlay() }
-            .onChange(of: motionViewModel.isMotionEnabled) { syncOverlay() }
+            .task { syncOverlayMounting() }
+            .onChange(of: appEnabled) { _, newValue in
+                if !newValue && motionViewModel.isMotionEnabled {
+                    motionViewModel.stopDeviceMotion()
+                }
+                syncOverlayMounting()
+            }
+            .onChange(of: motionViewModel.isMotionEnabled) { syncOverlayMounting() }
         }
         .menuBarExtraStyle(.window)
 
         Settings { EmptyView() }
     }
 
-    private func syncOverlay() {
+    private func syncOverlayMounting() {
         if appEnabled && motionViewModel.isMotionEnabled {
             overlay.install()
         } else {
             overlay.uninstall()
-            // If the user disabled visual cues while motion was running,
-            // stop the motion manager too so AirPods aren't read for nothing.
-            if !appEnabled && motionViewModel.isMotionEnabled {
-                motionViewModel.stopDeviceMotion()
-            }
         }
     }
 }

--- a/Mac Motion Cues/Mac_Motion_CuesApp.swift
+++ b/Mac Motion Cues/Mac_Motion_CuesApp.swift
@@ -1,5 +1,4 @@
 import AppKit
-import Combine
 import Sparkle
 import SwiftUI
 

--- a/Mac Motion Cues/Mac_Motion_CuesApp.swift
+++ b/Mac Motion Cues/Mac_Motion_CuesApp.swift
@@ -4,88 +4,45 @@ import SwiftUI
 
 @main
 struct MacMotionCuesApp: App {
-    // Use StateObject for view models that should persist
-    var dotsViewModel = DotsViewModel.shared
     var motionViewModel = MotionViewModel.shared
     private let updaterController: SPUStandardUpdaterController
-    // App-wide settings
+    @State private var overlay = OverlayWindowController()
     @AppStorage("appEnabled") private var appEnabled: Bool = true
-    
+
     init() {
-        // If you want to start the updater manually, pass false to startingUpdater and call .startUpdater() later
-        // This is where you can also pass an updater delegate if you need one
-        updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
+        updaterController = SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: nil,
+            userDriverDelegate: nil
+        )
     }
-    
+
     var body: some Scene {
-        // Only show the window when app is enabled
-        WindowGroup {
-            if appEnabled && motionViewModel.isMotionEnabled {
-                DotsView(dotsViewModel: dotsViewModel, motionViewModel: motionViewModel)
-                    .background(TransparentWindow())
-            } else {
-                // Empty view when disabled
-                VStack {}
-                    .background(TransparentWindow())
-            }
-        }
-        .windowStyle(.hiddenTitleBar)
-        .commands {
-            CommandGroup(after: .appInfo) {
-                CheckForUpdatesView(updater: updaterController.updater)
-            }
-        }
-        
-        // Enhanced menu bar with more options
         MenuBarExtra("Motion Cues", systemImage: "cursorarrow.motionlines.click") {
-            MenuBar(dotsViewModel: dotsViewModel, motionViewModel: motionViewModel)
+            MenuBar(
+                motionViewModel: motionViewModel,
+                settings: DotsSettings.shared,
+                overlay: overlay
+            )
+            .task { syncOverlay() }
+            .onChange(of: appEnabled) { syncOverlay() }
+            .onChange(of: motionViewModel.isMotionEnabled) { syncOverlay() }
         }
         .menuBarExtraStyle(.window)
-    }
-}
 
-class TransparentWindowView: NSView {
-    override func viewDidMoveToWindow() {
-        guard let window = window else { return }
-        
-        // Configure window properties
-        window.backgroundColor = .clear
-        window.isOpaque = false
-        
-        // Use .floating to stay above standard windows but below full-screen apps
-        window.level = .floating
-        
-        // Critical: Make the entire window completely click-through
-        window.ignoresMouseEvents = true
-        
-        // Ensure no interaction with window
-        window.isMovableByWindowBackground = false
-        window.hasShadow = false
-        
-        // Hide title bar elements
-        window.titleVisibility = .hidden
-        window.titlebarAppearsTransparent = true
-        window.styleMask.insert(.fullSizeContentView)
-        window.styleMask.insert(.borderless)
-        
-        // Hide standard window buttons
-        window.standardWindowButton(.closeButton)?.isHidden = true
-        window.standardWindowButton(.miniaturizeButton)?.isHidden = true
-        window.standardWindowButton(.zoomButton)?.isHidden = true
-        
-        // Make it screen size
-        if let mainScreen = NSScreen.main {
-            window.setFrame(mainScreen.frame, display: true)
+        Settings { EmptyView() }
+    }
+
+    private func syncOverlay() {
+        if appEnabled && motionViewModel.isMotionEnabled {
+            overlay.install()
+        } else {
+            overlay.uninstall()
+            // If the user disabled visual cues while motion was running,
+            // stop the motion manager too so AirPods aren't read for nothing.
+            if !appEnabled && motionViewModel.isMotionEnabled {
+                motionViewModel.stopDeviceMotion()
+            }
         }
-        
-        super.viewDidMoveToWindow()
     }
-    
-    // No need for hit testing since we're ignoring all mouse events
-}
-
-// Fix the typo in the struct name
-struct TransparentWindow: NSViewRepresentable {
-    func updateNSView(_ nsView: NSView, context: Context) {}
-    func makeNSView(context: Self.Context) -> NSView { return TransparentWindowView() }
 }

--- a/Mac Motion Cues/Mac_Motion_CuesApp.swift
+++ b/Mac Motion Cues/Mac_Motion_CuesApp.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 @main
 struct MacMotionCuesApp: App {
-    private let motionViewModel = MotionViewModel.shared
+    private let pipeline = MotionPipeline.shared
     private let appState = AppState.shared
     private let overlay = OverlayWindowController()
     private let updaterController: SPUStandardUpdaterController
@@ -17,11 +17,11 @@ struct MacMotionCuesApp: App {
         )
         // Defer to the next runloop tick so NSApp is fully up before we
         // touch the headphone motion manager or create overlay windows.
-        DispatchQueue.main.async { [motionViewModel, overlay, appState] in
-            motionViewModel.bootstrap()
+        DispatchQueue.main.async { [pipeline, overlay, appState] in
+            pipeline.bootstrap()
             overlay.startObservingMountConditions(
                 appState: appState,
-                motionViewModel: motionViewModel
+                pipeline: pipeline
             )
         }
     }
@@ -29,7 +29,7 @@ struct MacMotionCuesApp: App {
     var body: some Scene {
         MenuBarExtra("Motion Cues", systemImage: "cursorarrow.motionlines.click") {
             MenuBar(
-                motionViewModel: motionViewModel,
+                pipeline: pipeline,
                 appState: appState,
                 settings: DotsSettings.shared
             )

--- a/Mac Motion Cues/Model/Dot.swift
+++ b/Mac Motion Cues/Model/Dot.swift
@@ -7,17 +7,9 @@
 
 import SwiftUI
 
-struct Dot: Identifiable, Animatable {
+struct Dot: Identifiable {
     var id = UUID()
     var offsetY: CGFloat
     var offsetX: CGFloat = 0
     var size: CGFloat
-
-    var animatableData: AnimatablePair<CGFloat, CGFloat> {
-        get { AnimatablePair(offsetX, offsetY) }
-        set {
-            offsetX = newValue.first
-            offsetY = newValue.second
-        }
-    }
 }

--- a/Mac Motion Cues/Motion/AirPodsMotionSource.swift
+++ b/Mac Motion Cues/Motion/AirPodsMotionSource.swift
@@ -1,30 +1,24 @@
 import AppKit
 import CoreMotion
 import Foundation
-
-enum MotionState: Equatable {
-    case permissionNotDetermined
-    case permissionDenied
-    case noAirPods
-    case connecting
-    case streaming
-    case stale
-}
+import Observation
 
 @Observable
-final class MotionViewModel: NSObject, CMHeadphoneMotionManagerDelegate {
-    static let shared = MotionViewModel()
+final class AirPodsMotionSource: NSObject, MotionSource, CMHeadphoneMotionManagerDelegate {
+    static let id = "airpods"
+    static let displayName = "AirPods"
+    static let hardwareAvailability = HardwareAvailability.airpods
+    static let defaultPriority = 100
 
-    var state: MotionState = .permissionNotDetermined
-    var motionX: Double = 0.0
-    var motionY: Double = 0.0
+    static let shared = AirPodsMotionSource()
 
-    var isStreaming: Bool { state == .streaming }
+    private(set) var state: MotionSourceState = .permissionNotDetermined
+    private(set) var latestSample: VehicleMotionSample?
 
     private let motion = CMHeadphoneMotionManager()
     private let motionQueue: OperationQueue = {
         let q = OperationQueue()
-        q.name = "MotionQueue"
+        q.name = "AirPodsMotionQueue"
         q.qualityOfService = .userInteractive
         return q
     }()
@@ -41,14 +35,20 @@ final class MotionViewModel: NSObject, CMHeadphoneMotionManagerDelegate {
         applyAuthorizationStatus()
     }
 
+    func teardown() {
+        motion.stopDeviceMotionUpdates()
+        cancelStaleTimer()
+        if state == .streaming || state == .connecting || state == .stale {
+            transition(to: .idle)
+        }
+    }
+
     func requestPermission() {
         // First call to startDeviceMotionUpdates triggers the OS prompt when
-        // status is .notDetermined. The sample handler resolves the next
-        // state once the user accepts/denies.
+        // status is .notDetermined. The handler resolves the next state.
         motion.startDeviceMotionUpdates(to: motionQueue) { [weak self] sample, error in
-            guard let self else { return }
             DispatchQueue.main.async {
-                self.handleStreamCallback(sample: sample, error: error)
+                self?.handleStreamCallback(sample: sample, error: error)
             }
         }
     }
@@ -72,15 +72,13 @@ final class MotionViewModel: NSObject, CMHeadphoneMotionManagerDelegate {
         case .authorized:
             motion.startConnectionStatusUpdates()
             startSampleStream()
-            // `.connecting` is reserved for the delegate `didConnect` event
-            // (i.e. the brief gap between AirPods physically connecting and
-            // the first sample arriving). Default to `.noAirPods` here and
-            // let real signals; delegate callbacks or sample arrivals;
-            // drive forward transitions. Don't clobber an active state if
-            // bootstrap re-runs (e.g. when the menu is reopened).
+            // `.connecting` is reserved for the delegate `didConnect` event.
+            // Default to `.idle` (authorized but no AirPods) here and let real
+            // signals; delegate callbacks or sample arrivals; drive forward
+            // transitions. Don't clobber an active state if bootstrap re-runs.
             switch state {
-            case .permissionNotDetermined, .permissionDenied:
-                transition(to: .noAirPods)
+            case .permissionNotDetermined, .permissionDenied, .unavailable:
+                transition(to: .idle)
             default:
                 break
             }
@@ -99,15 +97,12 @@ final class MotionViewModel: NSObject, CMHeadphoneMotionManagerDelegate {
         if status == .notDetermined {
             return
         }
-        // Authorized from here on.
         motion.startConnectionStatusUpdates()
         if let sample {
             ingestSample(sample)
         } else if error != nil {
-            // No sample yet; assume AirPods aren't actively streaming.
-            // Delegate `didConnect` or a future sample will promote us forward.
             if state == .permissionNotDetermined || state == .permissionDenied {
-                transition(to: .noAirPods)
+                transition(to: .idle)
             }
         }
     }
@@ -115,38 +110,48 @@ final class MotionViewModel: NSObject, CMHeadphoneMotionManagerDelegate {
     private func startSampleStream() {
         guard !motion.isDeviceMotionActive else { return }
         motion.startDeviceMotionUpdates(to: motionQueue) { [weak self] sample, error in
-            guard let self else { return }
             DispatchQueue.main.async {
+                guard let self else { return }
                 if let sample {
                     self.ingestSample(sample)
                 } else if let error {
-                    print("Motion error: \(error.localizedDescription)")
+                    print("AirPods motion error: \(error.localizedDescription)")
                 }
             }
         }
     }
 
     private func ingestSample(_ sample: CMDeviceMotion) {
-        // Flip state BEFORE writing motion values so observers see .streaming
-        // before any consumer reads the new motion data; preserves the
-        // "isMotionEnabled before first paint" ordering invariant.
+        // Flip state BEFORE writing the sample so observers see `.streaming`
+        // before any consumer reads `latestSample`; preserves the
+        // "active source streaming before first paint" invariant.
         if state != .streaming {
             transition(to: .streaming)
         }
-        motionX = sample.userAcceleration.x
-        motionY = sample.userAcceleration.y
+        latestSample = VehicleMotionSample(
+            lateralAccel: sample.userAcceleration.x,
+            longitudinalAccel: sample.userAcceleration.y,
+            // rotationRate.z is the head's yaw angular velocity (rad/s);
+            // a direct signal for sustained turning, vs. integrating noisy
+            // lateral accel.
+            yawRate: sample.rotationRate.z,
+            confidence: 1.0,
+            timestamp: sample.timestamp
+        )
         resetStaleTimer()
     }
 
-    private func transition(to next: MotionState) {
+    private func transition(to next: MotionSourceState) {
         guard state != next else { return }
         state = next
         if next != .streaming {
             cancelStaleTimer()
         }
-        if next == .noAirPods || next == .permissionDenied || next == .permissionNotDetermined {
-            motionX = 0
-            motionY = 0
+        switch next {
+        case .idle, .permissionDenied, .permissionNotDetermined, .unavailable:
+            latestSample = nil
+        default:
+            break
         }
     }
 
@@ -173,7 +178,7 @@ final class MotionViewModel: NSObject, CMHeadphoneMotionManagerDelegate {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             guard CMHeadphoneMotionManager.authorizationStatus() == .authorized else { return }
-            if self.state == .noAirPods {
+            if self.state == .idle {
                 self.transition(to: .connecting)
                 self.startSampleStream()
             }
@@ -185,7 +190,7 @@ final class MotionViewModel: NSObject, CMHeadphoneMotionManagerDelegate {
             guard let self else { return }
             self.motion.stopDeviceMotionUpdates()
             if CMHeadphoneMotionManager.authorizationStatus() == .authorized {
-                self.transition(to: .noAirPods)
+                self.transition(to: .idle)
             }
         }
     }

--- a/Mac Motion Cues/Motion/CoreLocationDetectionSource.swift
+++ b/Mac Motion Cues/Motion/CoreLocationDetectionSource.swift
@@ -1,0 +1,142 @@
+import AppKit
+import CoreLocation
+import Foundation
+import Observation
+
+@Observable
+final class CoreLocationDetectionSource: NSObject, VehicleDetectionSource, CLLocationManagerDelegate {
+    static let id = "corelocation"
+    static let displayName = "Location services"
+    static let hardwareAvailability = HardwareAvailability.locationServices
+
+    static let shared = CoreLocationDetectionSource()
+
+    private(set) var state: MotionSourceState = .permissionNotDetermined
+    private(set) var inVehicle: Bool = false
+
+    /// Speed (m/s) at which we start counting toward "in vehicle". ~18 km/h.
+    private let entrySpeedThreshold: Double = 5.0
+    /// Speed (m/s) below which we start counting toward "stationary". ~3.6 km/h.
+    private let exitSpeedThreshold: Double = 1.0
+    private let entryHoldTime: TimeInterval = 5.0
+    private let exitHoldTime: TimeInterval = 30.0
+
+    private let manager: CLLocationManager
+    private var aboveEntrySince: Date?
+    private var belowExitSince: Date?
+    private var isActive: Bool = false
+
+    override init() {
+        self.manager = CLLocationManager()
+        super.init()
+        manager.delegate = self
+        manager.desiredAccuracy = kCLLocationAccuracyHundredMeters
+        manager.distanceFilter = 10
+    }
+
+    /// Called when the user enables this source. Triggers the OS prompt the
+    /// first time (status `.notDetermined`); on subsequent calls just resumes
+    /// updates if already authorized.
+    func bootstrap() {
+        isActive = true
+        if manager.authorizationStatus == .notDetermined {
+            transition(to: .permissionNotDetermined)
+            manager.requestWhenInUseAuthorization()
+        } else {
+            applyAuthorizationStatus()
+        }
+    }
+
+    func teardown() {
+        isActive = false
+        manager.stopUpdatingLocation()
+        inVehicle = false
+        aboveEntrySince = nil
+        belowExitSince = nil
+        if state == .streaming || state == .connecting {
+            transition(to: .idle)
+        }
+    }
+
+    static func openSystemSettings() {
+        let primary = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_LocationServices")!
+        if NSWorkspace.shared.open(primary) { return }
+        if let fallback = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy") {
+            NSWorkspace.shared.open(fallback)
+        }
+    }
+
+    // MARK: - State transitions
+
+    /// Observes the current authorization status; never triggers a prompt.
+    /// The `isActive` flag gates whether we actually start streaming when
+    /// authorized; important because the delegate's didChangeAuthorization
+    /// callback fires once on init, before the user has enabled this source.
+    private func applyAuthorizationStatus() {
+        switch manager.authorizationStatus {
+        case .notDetermined:
+            transition(to: .permissionNotDetermined)
+        case .denied, .restricted:
+            transition(to: .permissionDenied)
+            manager.stopUpdatingLocation()
+        case .authorized, .authorizedAlways, .authorizedWhenInUse:
+            if isActive {
+                transition(to: .streaming)
+                manager.startUpdatingLocation()
+            } else {
+                transition(to: .idle)
+            }
+        @unknown default:
+            transition(to: .permissionDenied)
+        }
+    }
+
+    private func transition(to next: MotionSourceState) {
+        guard state != next else { return }
+        state = next
+        if next != .streaming {
+            inVehicle = false
+            aboveEntrySince = nil
+            belowExitSince = nil
+        }
+    }
+
+    // MARK: - CLLocationManagerDelegate
+
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        DispatchQueue.main.async { [weak self] in
+            self?.applyAuthorizationStatus()
+        }
+    }
+
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self, let latest = locations.last else { return }
+            self.processLocation(latest)
+        }
+    }
+
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        // Transient failures (no GPS yet, etc.) are common; ignore.
+    }
+
+    private func processLocation(_ location: CLLocation) {
+        let speed = max(0, location.speed)        // CLLocation.speed is -1 when invalid
+        let now = location.timestamp
+
+        if speed >= entrySpeedThreshold {
+            if aboveEntrySince == nil { aboveEntrySince = now }
+            belowExitSince = nil
+            if !inVehicle, let since = aboveEntrySince, now.timeIntervalSince(since) >= entryHoldTime {
+                inVehicle = true
+            }
+        } else if speed <= exitSpeedThreshold {
+            if belowExitSince == nil { belowExitSince = now }
+            aboveEntrySince = nil
+            if inVehicle, let since = belowExitSince, now.timeIntervalSince(since) >= exitHoldTime {
+                inVehicle = false
+            }
+        }
+        // Between thresholds: keep current state, don't reset hold timers.
+    }
+}

--- a/Mac Motion Cues/Motion/MotionPipeline.swift
+++ b/Mac Motion Cues/Motion/MotionPipeline.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Observation
+
+@Observable
+final class MotionPipeline {
+    static let shared = MotionPipeline()
+
+    let motionSources: [any MotionSource]
+    let detectionSources: [any VehicleDetectionSource]
+
+    var enabledMotionSourceIDs: Set<String> {
+        didSet { defaults.set(Array(enabledMotionSourceIDs), forKey: Keys.motionSources) }
+    }
+    var enabledDetectionSourceIDs: Set<String> {
+        didSet { defaults.set(Array(enabledDetectionSourceIDs), forKey: Keys.detectionSources) }
+    }
+
+    private let defaults = UserDefaults.standard
+    private enum Keys {
+        static let motionSources = "enabledMotionSourceIDs"
+        static let detectionSources = "enabledDetectionSourceIDs"
+    }
+
+    private init() {
+        self.motionSources = [AirPodsMotionSource.shared]
+        self.detectionSources = [CoreLocationDetectionSource.shared]
+
+        defaults.register(defaults: [
+            Keys.motionSources: [AirPodsMotionSource.id],
+            Keys.detectionSources: [String](),    // off by default; user opts in
+        ])
+        self.enabledMotionSourceIDs = Set(defaults.stringArray(forKey: Keys.motionSources) ?? [])
+        self.enabledDetectionSourceIDs = Set(defaults.stringArray(forKey: Keys.detectionSources) ?? [])
+    }
+
+    /// Highest-priority enabled source that is `.streaming`; falls back to
+    /// highest-priority enabled source so the UI still has a state to render
+    /// even when nothing is streaming.
+    var activeMotionSource: (any MotionSource)? {
+        let enabled = motionSources.filter { enabledMotionSourceIDs.contains($0.id) }
+        let streaming = enabled.filter { $0.state == .streaming }
+        return streaming.max(by: { Self.priority($0) < Self.priority($1) })
+            ?? enabled.max(by: { Self.priority($0) < Self.priority($1) })
+    }
+
+    var latestSample: VehicleMotionSample? { activeMotionSource?.latestSample }
+
+    var isStreaming: Bool { activeMotionSource?.state == .streaming }
+
+    func shouldRenderCues(appEnabled: Bool) -> Bool {
+        guard appEnabled else { return false }
+        guard isStreaming else { return false }
+        let activeDetections = detectionSources.filter { enabledDetectionSourceIDs.contains($0.id) }
+        if activeDetections.isEmpty { return true }
+        return activeDetections.contains { $0.inVehicle }
+    }
+
+    func bootstrap() {
+        for src in motionSources where enabledMotionSourceIDs.contains(src.id) {
+            src.bootstrap()
+        }
+        for src in detectionSources where enabledDetectionSourceIDs.contains(src.id) {
+            src.bootstrap()
+        }
+    }
+
+    func setMotionSource(_ id: String, enabled: Bool) {
+        guard let src = motionSources.first(where: { $0.id == id }) else { return }
+        if enabled {
+            enabledMotionSourceIDs.insert(id)
+            src.bootstrap()
+        } else {
+            enabledMotionSourceIDs.remove(id)
+            src.teardown()
+        }
+    }
+
+    func setDetectionSource(_ id: String, enabled: Bool) {
+        guard let src = detectionSources.first(where: { $0.id == id }) else { return }
+        if enabled {
+            enabledDetectionSourceIDs.insert(id)
+            src.bootstrap()
+        } else {
+            enabledDetectionSourceIDs.remove(id)
+            src.teardown()
+        }
+    }
+
+    private static func priority(_ src: any MotionSource) -> Int {
+        type(of: src).defaultPriority
+    }
+}

--- a/Mac Motion Cues/Motion/MotionSource.swift
+++ b/Mac Motion Cues/Motion/MotionSource.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Observation
+
+/// A normalized motion sample produced by a `MotionSource`. Frame conventions
+/// are source-specific (head frame for AirPods, device frame for an on-board
+/// IMU, etc.); each source is responsible for any conversion before emitting.
+struct VehicleMotionSample: Equatable {
+    let lateralAccel: Double
+    let longitudinalAccel: Double
+    let yawRate: Double           // rad/s, signed
+    let confidence: Double        // 0...1, source-reported (kept for future fusion)
+    let timestamp: TimeInterval
+}
+
+enum MotionSourceState: Equatable {
+    case unavailable(reason: String)
+    case permissionNotDetermined
+    case permissionDenied
+    case idle                      // permission/hardware OK, not yet streaming
+    case connecting
+    case streaming
+    case stale
+    case error(String)
+}
+
+enum HardwareAvailability {
+    case airpods
+    case locationServices
+    case appleSiliconLaptop        // reserved for a future MacBookIMUMotionSource
+}
+
+/// Drives the dot motion. One active `MotionSource` at a time wins by priority.
+protocol MotionSource: AnyObject, Identifiable, Observable {
+    static var id: String { get }
+    static var displayName: String { get }
+    static var hardwareAvailability: HardwareAvailability { get }
+    static var defaultPriority: Int { get }
+
+    var state: MotionSourceState { get }
+    var latestSample: VehicleMotionSample? { get }
+
+    func bootstrap()
+    func teardown()
+}
+
+extension MotionSource {
+    var id: String { Self.id }
+}
+
+/// Gates whether cues should render based on whether the user appears to be
+/// in a vehicle. Independent of motion drive; multiple detection sources can
+/// be enabled, and any one returning `inVehicle == true` opens the gate.
+protocol VehicleDetectionSource: AnyObject, Identifiable, Observable {
+    static var id: String { get }
+    static var displayName: String { get }
+    static var hardwareAvailability: HardwareAvailability { get }
+
+    var state: MotionSourceState { get }
+    var inVehicle: Bool { get }
+
+    func bootstrap()
+    func teardown()
+}
+
+extension VehicleDetectionSource {
+    var id: String { Self.id }
+}

--- a/Mac Motion Cues/View/DotsView.swift
+++ b/Mac Motion Cues/View/DotsView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct DotsView: View {
     @Bindable var dotsViewModel: DotsViewModel
-    @Bindable var motionViewModel: MotionViewModel
+    @Bindable var pipeline: MotionPipeline
 
     private let haloLineWidth: CGFloat = 1.5
     private let haloGap: CGFloat = 1.0
@@ -11,7 +11,7 @@ struct DotsView: View {
     var body: some View {
         let settings = DotsSettings.shared
         GeometryReader { geometry in
-            TimelineView(.animation(minimumInterval: 1 / 30, paused: !motionViewModel.isStreaming)) { context in
+            TimelineView(.animation(minimumInterval: 1 / 30, paused: !pipeline.isStreaming)) { context in
                 ZStack {
                     ForEach(dotsViewModel.dots.indices, id: \.self) { index in
                         let dot = dotsViewModel.dots[index]

--- a/Mac Motion Cues/View/DotsView.swift
+++ b/Mac Motion Cues/View/DotsView.swift
@@ -1,17 +1,15 @@
-import Combine
 import SwiftUI
 
 struct DotsView: View {
     @Bindable var dotsViewModel: DotsViewModel
     @Bindable var motionViewModel: MotionViewModel
 
-    @State private var scrollingCancellable: AnyCancellable?
-
     var body: some View {
         GeometryReader { geometry in
             TimelineView(.animation(minimumInterval: 1 / 30, paused: !motionViewModel.isMotionEnabled)) { context in
                 ZStack {
-                    ForEach(Array(dotsViewModel.dots.enumerated()), id: \.element.id) { index, dot in
+                    ForEach(dotsViewModel.dots.indices, id: \.self) { index in
+                        let dot = dotsViewModel.dots[index]
                         Circle()
                             .fill(.black)
                             .frame(width: dot.size, height: dot.size)
@@ -30,9 +28,6 @@ struct DotsView: View {
                 }
                 .onAppear {
                     dotsViewModel.initializeDots(screenHeight: geometry.size.height)
-                }
-                .onDisappear {
-                    scrollingCancellable?.cancel()
                 }
             }
         }

--- a/Mac Motion Cues/View/DotsView.swift
+++ b/Mac Motion Cues/View/DotsView.swift
@@ -29,6 +29,9 @@ struct DotsView: View {
                 .onAppear {
                     dotsViewModel.initializeDots(screenHeight: geometry.size.height)
                 }
+                .onDisappear {
+                    motionViewModel.stopDeviceMotion()
+                }
             }
         }
     }

--- a/Mac Motion Cues/View/DotsView.swift
+++ b/Mac Motion Cues/View/DotsView.swift
@@ -23,8 +23,6 @@ struct DotsView: View {
                             )
                             .opacity(dot.offsetY < dotsViewModel.dotSize ||
                                 dot.offsetY > geometry.size.height - 150 ? 0 : 1)
-                            .animation(.easeInOut(duration: 0.06), value: dot.offsetY)
-                            .animation(.easeInOut(duration: 0.06), value: dot.offsetX)
                     }
                 }
                 .onChange(of: context.date) {

--- a/Mac Motion Cues/View/DotsView.swift
+++ b/Mac Motion Cues/View/DotsView.swift
@@ -11,7 +11,7 @@ struct DotsView: View {
     var body: some View {
         let settings = DotsSettings.shared
         GeometryReader { geometry in
-            TimelineView(.animation(minimumInterval: 1 / 30, paused: !motionViewModel.isMotionEnabled)) { context in
+            TimelineView(.animation(minimumInterval: 1 / 30, paused: !motionViewModel.isStreaming)) { context in
                 ZStack {
                     ForEach(dotsViewModel.dots.indices, id: \.self) { index in
                         let dot = dotsViewModel.dots[index]

--- a/Mac Motion Cues/View/DotsView.swift
+++ b/Mac Motion Cues/View/DotsView.swift
@@ -8,6 +8,13 @@ struct DotsView: View {
     private let haloLineWidth: CGFloat = 1.5
     private let haloGap: CGFloat = 1.0
 
+    private func edgeFadeOpacity(y: CGFloat, height: CGFloat, fadeRange: CGFloat, inset: CGFloat) -> Double {
+        guard fadeRange > 0 else { return 1 }
+        let topRamp = max(0, min(1, (y - inset) / fadeRange))
+        let bottomRamp = max(0, min(1, (height - inset - y) / fadeRange))
+        return Double(min(topRamp, bottomRamp))
+    }
+
     var body: some View {
         let settings = DotsSettings.shared
         GeometryReader { geometry in
@@ -39,8 +46,7 @@ struct DotsView: View {
                                 : geometry.size.width - 150 + dot.offsetX,
                             y: dot.offsetY
                         )
-                        .opacity(dot.offsetY < DotsSettings.shared.dotSize ||
-                            dot.offsetY > geometry.size.height - 150 ? 0 : 1)
+                        .opacity(edgeFadeOpacity(y: dot.offsetY, height: geometry.size.height, fadeRange: dot.size * 2, inset: dot.size))
                     }
                 }
                 .onChange(of: context.date) {

--- a/Mac Motion Cues/View/DotsView.swift
+++ b/Mac Motion Cues/View/DotsView.swift
@@ -1,27 +1,15 @@
 import AppKit
 import SwiftUI
 
-enum DotStyle: String, CaseIterable {
-    case solid
-    case dynamic
-}
-
-enum HaloStyle: String, CaseIterable {
-    case off
-    case solid
-    case dynamic
-}
-
 struct DotsView: View {
     @Bindable var dotsViewModel: DotsViewModel
     @Bindable var motionViewModel: MotionViewModel
-    @AppStorage("dotStyle") private var dotStyle: DotStyle = .dynamic
-    @AppStorage("haloStyle") private var haloStyle: HaloStyle = .dynamic
 
     private let haloLineWidth: CGFloat = 1.5
     private let haloGap: CGFloat = 1.0
 
     var body: some View {
+        let settings = DotsSettings.shared
         GeometryReader { geometry in
             TimelineView(.animation(minimumInterval: 1 / 30, paused: !motionViewModel.isMotionEnabled)) { context in
                 ZStack {
@@ -29,18 +17,18 @@ struct DotsView: View {
                         let dot = dotsViewModel.dots[index]
                         ZStack {
                             Group {
-                                if dotStyle == .solid {
+                                if settings.dotStyle == .solid {
                                     Circle().fill(.black)
                                 } else {
                                     VibrantCircle()
                                 }
                             }
-                            .padding(haloStyle != .off ? haloLineWidth + haloGap : 0)
+                            .padding(settings.haloStyle != .off ? haloLineWidth + haloGap : 0)
 
-                            if haloStyle == .solid {
+                            if settings.haloStyle == .solid {
                                 Circle().strokeBorder(Color.black.opacity(0.5), lineWidth: haloLineWidth)
                             }
-                            if haloStyle == .dynamic {
+                            if settings.haloStyle == .dynamic {
                                 VibrantRing(lineWidth: haloLineWidth)
                             }
                         }

--- a/Mac Motion Cues/View/DotsView.swift
+++ b/Mac Motion Cues/View/DotsView.swift
@@ -1,8 +1,25 @@
+import AppKit
 import SwiftUI
+
+enum DotStyle: String, CaseIterable {
+    case solid
+    case dynamic
+}
+
+enum HaloStyle: String, CaseIterable {
+    case off
+    case solid
+    case dynamic
+}
 
 struct DotsView: View {
     @Bindable var dotsViewModel: DotsViewModel
     @Bindable var motionViewModel: MotionViewModel
+    @AppStorage("dotStyle") private var dotStyle: DotStyle = .dynamic
+    @AppStorage("haloStyle") private var haloStyle: HaloStyle = .dynamic
+
+    private let haloLineWidth: CGFloat = 1.5
+    private let haloGap: CGFloat = 1.0
 
     var body: some View {
         GeometryReader { geometry in
@@ -10,17 +27,32 @@ struct DotsView: View {
                 ZStack {
                     ForEach(dotsViewModel.dots.indices, id: \.self) { index in
                         let dot = dotsViewModel.dots[index]
-                        Circle()
-                            .fill(.black)
-                            .frame(width: dot.size, height: dot.size)
-                            .position(
-                                x: index % 2 == 0
-                                    ? 150 + dot.offsetX
-                                    : geometry.size.width - 150 + dot.offsetX,
-                                y: dot.offsetY
-                            )
-                            .opacity(dot.offsetY < dotsViewModel.dotSize ||
-                                dot.offsetY > geometry.size.height - 150 ? 0 : 1)
+                        ZStack {
+                            Group {
+                                if dotStyle == .solid {
+                                    Circle().fill(.black)
+                                } else {
+                                    VibrantCircle()
+                                }
+                            }
+                            .padding(haloStyle != .off ? haloLineWidth + haloGap : 0)
+
+                            if haloStyle == .solid {
+                                Circle().strokeBorder(Color.black.opacity(0.5), lineWidth: haloLineWidth)
+                            }
+                            if haloStyle == .dynamic {
+                                VibrantRing(lineWidth: haloLineWidth)
+                            }
+                        }
+                        .frame(width: dot.size, height: dot.size)
+                        .position(
+                            x: index % 2 == 0
+                                ? 150 + dot.offsetX
+                                : geometry.size.width - 150 + dot.offsetX,
+                            y: dot.offsetY
+                        )
+                        .opacity(dot.offsetY < dotsViewModel.dotSize ||
+                            dot.offsetY > geometry.size.height - 150 ? 0 : 1)
                     }
                 }
                 .onChange(of: context.date) {
@@ -34,5 +66,68 @@ struct DotsView: View {
                 }
             }
         }
+    }
+}
+
+final class CircularEffectView: NSVisualEffectView {
+    override func layout() {
+        super.layout()
+        layer?.cornerRadius = bounds.width / 2
+    }
+}
+
+struct VibrantCircle: NSViewRepresentable {
+    func makeNSView(context: Context) -> CircularEffectView {
+        let view = CircularEffectView()
+        view.blendingMode = .behindWindow
+        view.material = .hudWindow
+        view.state = .active
+        view.wantsLayer = true
+        view.layer?.masksToBounds = true
+        return view
+    }
+
+    func updateNSView(_ nsView: CircularEffectView, context: Context) {}
+}
+
+final class RingEffectView: NSVisualEffectView {
+    var lineWidth: CGFloat = 1.5 {
+        didSet { needsLayout = true }
+    }
+
+    override func layout() {
+        super.layout()
+        if bounds.width > 0, bounds.height > 0 {
+            maskImage = Self.annulusMask(size: bounds.size, lineWidth: lineWidth)
+        }
+    }
+
+    private static func annulusMask(size: NSSize, lineWidth: CGFloat) -> NSImage {
+        NSImage(size: size, flipped: false) { rect in
+            NSColor.black.setFill()
+            let path = NSBezierPath(ovalIn: rect)
+            path.append(NSBezierPath(ovalIn: rect.insetBy(dx: lineWidth, dy: lineWidth)))
+            path.windingRule = .evenOdd
+            path.fill()
+            return true
+        }
+    }
+}
+
+struct VibrantRing: NSViewRepresentable {
+    let lineWidth: CGFloat
+
+    func makeNSView(context: Context) -> RingEffectView {
+        let view = RingEffectView()
+        view.blendingMode = .behindWindow
+        view.material = .menu
+        view.state = .active
+        view.wantsLayer = true
+        view.lineWidth = lineWidth
+        return view
+    }
+
+    func updateNSView(_ nsView: RingEffectView, context: Context) {
+        nsView.lineWidth = lineWidth
     }
 }

--- a/Mac Motion Cues/View/DotsView.swift
+++ b/Mac Motion Cues/View/DotsView.swift
@@ -51,7 +51,7 @@ struct DotsView: View {
                                 : geometry.size.width - 150 + dot.offsetX,
                             y: dot.offsetY
                         )
-                        .opacity(dot.offsetY < dotsViewModel.dotSize ||
+                        .opacity(dot.offsetY < DotsSettings.shared.dotSize ||
                             dot.offsetY > geometry.size.height - 150 ? 0 : 1)
                     }
                 }
@@ -61,8 +61,8 @@ struct DotsView: View {
                 .onAppear {
                     dotsViewModel.initializeDots(screenHeight: geometry.size.height)
                 }
-                .onDisappear {
-                    motionViewModel.stopDeviceMotion()
+                .onChange(of: geometry.size.height) {
+                    dotsViewModel.initializeDots(screenHeight: geometry.size.height)
                 }
             }
         }

--- a/Mac Motion Cues/View/MenuBar.swift
+++ b/Mac Motion Cues/View/MenuBar.swift
@@ -3,53 +3,55 @@ import Sparkle
 import SwiftUI
 
 struct MenuBar: View {
-    @Bindable var dotsViewModel: DotsViewModel
     @Bindable var motionViewModel: MotionViewModel
+    @Bindable var settings: DotsSettings
+    let overlay: OverlayWindowController
     @AppStorage("appEnabled") private var appEnabled: Bool = true
     @AppStorage("dotStyle") private var dotStyle: DotStyle = .dynamic
     @AppStorage("haloStyle") private var haloStyle: HaloStyle = .dynamic
-    
+
     var body: some View {
         VStack(alignment: .center, spacing: 15) {
             Text("Mac Motion Cues")
                 .font(.headline)
                 .padding(.top)
-        
+
             Toggle("Enable Visual Cues", isOn: $appEnabled)
                 .toggleStyle(.switch)
                 .padding(.horizontal)
-        
+
             Divider()
-        
+
             if appEnabled {
                 GroupBox {
                     Text("Visual Settings")
                         .font(.subheadline)
                         .padding(.bottom, 5)
-                    
+
                     VStack(spacing: 10) {
                         HStack {
                             Text("Size")
-                            Slider(value: $dotsViewModel.dotSize, in: 10...30, step: 1)
-                                .onChange(of: dotsViewModel.dotSize) {
-                                    dotsViewModel.updateDotSize()
+                            Slider(value: $settings.dotSize, in: 10...30, step: 1)
+                                .onChange(of: settings.dotSize) {
+                                    settings.ensureSpacingFitsSize()
+                                    overlay.notifySettingsChanged()
                                 }
-                            Text("\(Int(dotsViewModel.dotSize))")
+                            Text("\(Int(settings.dotSize))")
                                 .frame(width: 40, alignment: .trailing)
                                 .monospacedDigit()
                         }
-                        
+
                         HStack {
                             Text("Spacing")
                             Slider(
-                                value: $dotsViewModel.verticalSpacing,
+                                value: $settings.verticalSpacing,
                                 in: 20...100,
                                 step: 5
                             )
-                            .onChange(of: dotsViewModel.verticalSpacing) {
-                                dotsViewModel.updateSpacing()
+                            .onChange(of: settings.verticalSpacing) {
+                                overlay.notifySettingsChanged()
                             }
-                            Text("\(Int(dotsViewModel.verticalSpacing))")
+                            Text("\(Int(settings.verticalSpacing))")
                                 .frame(width: 40, alignment: .trailing)
                                 .monospacedDigit()
                         }
@@ -97,7 +99,7 @@ struct MenuBar: View {
                     Text("Motion Settings")
                         .font(.subheadline)
                         .padding(.bottom, 5)
-                    
+
                     VStack(spacing: 10) {
                         Button {
                             Task {
@@ -112,7 +114,7 @@ struct MenuBar: View {
                                 .frame(maxWidth: .infinity)
                         }
                         .buttonStyle(.borderedProminent)
-                        
+
                         if motionViewModel.isMotionEnabled {
                             HStack {
                                 Image(systemName: "airpods")
@@ -121,54 +123,54 @@ struct MenuBar: View {
                                     .fill(Color.green)
                                     .frame(width: 8, height: 8)
                             }
-                            
+
                             HStack {
                                 Text("Sensitivity")
-                                Slider(value: $dotsViewModel.motionSensitivity, in: 1...20, step: 1)
-                                Text("\(Int(dotsViewModel.motionSensitivity))")
+                                Slider(value: $settings.motionSensitivity, in: 1...20, step: 1)
+                                Text("\(Int(settings.motionSensitivity))")
                                     .frame(width: 40, alignment: .trailing)
                                     .monospacedDigit()
                             }
-                            
+
                             HStack {
                                 Text("X: \(String(format: "%.2f", motionViewModel.motionX))")
                                 Text("Y: \(String(format: "%.2f", motionViewModel.motionY))")
                             }
-                            
+
                             HStack {
-                                Toggle("Enable X Motion (BETA)", isOn: $dotsViewModel.xMotionEnabled)
+                                Toggle("Enable X Motion (BETA)", isOn: $settings.xMotionEnabled)
                                     .toggleStyle(.switch)
                             }
                         }
                     }
                 }
                 .padding(.horizontal)
-                
+
                 Divider()
             }
-        
+
             GroupBox {
                 VStack(alignment: .center, spacing: 5) {
                     Text("About")
                         .font(.subheadline)
-                
+
                     Text("Mac Motion Cues")
                         .font(.caption)
                         .foregroundColor(.secondary)
-                
+
                     Link("View Source Code", destination: URL(string: "https://github.com/Lospi/MacMotionCues")!)
                         .font(.caption)
                 }
             }
             .padding(.horizontal)
-        
+
             Divider()
-        
+
             LaunchAtLogin.Toggle {
                 Text("Launch at Login")
             }
             UpdateView()
-                
+
             Button("Quit Mac Motion Cues") {
                 NSApplication.shared.terminate(nil)
             }

--- a/Mac Motion Cues/View/MenuBar.swift
+++ b/Mac Motion Cues/View/MenuBar.swift
@@ -6,6 +6,8 @@ struct MenuBar: View {
     @Bindable var dotsViewModel: DotsViewModel
     @Bindable var motionViewModel: MotionViewModel
     @AppStorage("appEnabled") private var appEnabled: Bool = true
+    @AppStorage("dotStyle") private var dotStyle: DotStyle = .dynamic
+    @AppStorage("haloStyle") private var haloStyle: HaloStyle = .dynamic
     
     var body: some View {
         VStack(alignment: .center, spacing: 15) {
@@ -54,9 +56,43 @@ struct MenuBar: View {
                     }
                 }
                 .padding(.horizontal)
-                
+
                 Divider()
-                
+
+                GroupBox {
+                    Text("Dot Style")
+                        .font(.subheadline)
+                        .padding(.bottom, 5)
+
+                    VStack(alignment: .leading, spacing: 10) {
+                        HStack {
+                            Text("Style")
+                                .frame(width: 50, alignment: .leading)
+                            Picker("Style", selection: $dotStyle) {
+                                Text("Solid").tag(DotStyle.solid)
+                                Text("Dynamic").tag(DotStyle.dynamic)
+                            }
+                            .pickerStyle(.segmented)
+                            .labelsHidden()
+                        }
+
+                        HStack {
+                            Text("Halo")
+                                .frame(width: 50, alignment: .leading)
+                            Picker("Halo", selection: $haloStyle) {
+                                Text("Off").tag(HaloStyle.off)
+                                Text("Solid").tag(HaloStyle.solid)
+                                Text("Dynamic").tag(HaloStyle.dynamic)
+                            }
+                            .pickerStyle(.segmented)
+                            .labelsHidden()
+                        }
+                    }
+                }
+                .padding(.horizontal)
+
+                Divider()
+
                 GroupBox {
                     Text("Motion Settings")
                         .font(.subheadline)

--- a/Mac Motion Cues/View/MenuBar.swift
+++ b/Mac Motion Cues/View/MenuBar.swift
@@ -5,7 +5,6 @@ import SwiftUI
 struct MenuBar: View {
     @Bindable var motionViewModel: MotionViewModel
     @Bindable var settings: DotsSettings
-    let overlay: OverlayWindowController
     @AppStorage("appEnabled") private var appEnabled: Bool = true
 
     var body: some View {
@@ -30,10 +29,6 @@ struct MenuBar: View {
                         HStack {
                             Text("Size")
                             Slider(value: $settings.dotSize, in: 10...30, step: 1)
-                                .onChange(of: settings.dotSize) {
-                                    settings.ensureSpacingFitsSize()
-                                    overlay.notifySettingsChanged()
-                                }
                             Text("\(Int(settings.dotSize))")
                                 .frame(width: 40, alignment: .trailing)
                                 .monospacedDigit()
@@ -46,9 +41,6 @@ struct MenuBar: View {
                                 in: 20...100,
                                 step: 5
                             )
-                            .onChange(of: settings.verticalSpacing) {
-                                overlay.notifySettingsChanged()
-                            }
                             Text("\(Int(settings.verticalSpacing))")
                                 .frame(width: 40, alignment: .trailing)
                                 .monospacedDigit()

--- a/Mac Motion Cues/View/MenuBar.swift
+++ b/Mac Motion Cues/View/MenuBar.swift
@@ -7,8 +7,6 @@ struct MenuBar: View {
     @Bindable var settings: DotsSettings
     let overlay: OverlayWindowController
     @AppStorage("appEnabled") private var appEnabled: Bool = true
-    @AppStorage("dotStyle") private var dotStyle: DotStyle = .dynamic
-    @AppStorage("haloStyle") private var haloStyle: HaloStyle = .dynamic
 
     var body: some View {
         VStack(alignment: .center, spacing: 15) {
@@ -70,7 +68,7 @@ struct MenuBar: View {
                         HStack {
                             Text("Style")
                                 .frame(width: 50, alignment: .leading)
-                            Picker("Style", selection: $dotStyle) {
+                            Picker("Style", selection: $settings.dotStyle) {
                                 Text("Solid").tag(DotStyle.solid)
                                 Text("Dynamic").tag(DotStyle.dynamic)
                             }
@@ -81,7 +79,7 @@ struct MenuBar: View {
                         HStack {
                             Text("Halo")
                                 .frame(width: 50, alignment: .leading)
-                            Picker("Halo", selection: $haloStyle) {
+                            Picker("Halo", selection: $settings.haloStyle) {
                                 Text("Off").tag(HaloStyle.off)
                                 Text("Solid").tag(HaloStyle.solid)
                                 Text("Dynamic").tag(HaloStyle.dynamic)

--- a/Mac Motion Cues/View/MenuBar.swift
+++ b/Mac Motion Cues/View/MenuBar.swift
@@ -3,7 +3,7 @@ import Sparkle
 import SwiftUI
 
 struct MenuBar: View {
-    @Bindable var motionViewModel: MotionViewModel
+    @Bindable var pipeline: MotionPipeline
     @Bindable var appState: AppState
     @Bindable var settings: DotsSettings
 
@@ -89,7 +89,7 @@ struct MenuBar: View {
                     .font(.subheadline)
                     .padding(.bottom, 5)
 
-                MotionStatusPanel(motionViewModel: motionViewModel, settings: settings)
+                MotionStatusPanel(pipeline: pipeline, settings: settings)
             }
             .padding(.horizontal)
 
@@ -128,39 +128,213 @@ struct MenuBar: View {
 }
 
 private struct MotionStatusPanel: View {
-    @Bindable var motionViewModel: MotionViewModel
+    @Bindable var pipeline: MotionPipeline
     @Bindable var settings: DotsSettings
 
+    private var activeState: MotionSourceState? {
+        pipeline.activeMotionSource?.state
+    }
+
+    private var isStreamingOrStale: Bool {
+        activeState == .streaming || activeState == .stale
+    }
+
     var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            ForEach(pipeline.motionSources.indices, id: \.self) { idx in
+                let source = pipeline.motionSources[idx]
+                MotionSourceRow(source: source, pipeline: pipeline)
+                if idx < pipeline.motionSources.count - 1 {
+                    Divider()
+                }
+            }
+
+            if !pipeline.detectionSources.isEmpty {
+                Divider()
+                Text("Auto-enable when in vehicle")
+                    .font(.caption.weight(.semibold))
+                    .foregroundColor(.secondary)
+                ForEach(pipeline.detectionSources.indices, id: \.self) { idx in
+                    let source = pipeline.detectionSources[idx]
+                    DetectionSourceRow(source: source, pipeline: pipeline)
+                }
+            }
+
+            if isStreamingOrStale {
+                Divider()
+                activeSettingsView
+            }
+        }
+    }
+
+    private var activeSettingsView: some View {
         VStack(alignment: .leading, spacing: 10) {
-            switch motionViewModel.state {
+            HStack {
+                Text("Sensitivity")
+                Slider(value: $settings.motionSensitivity, in: 1...20, step: 1)
+                Text("\(Int(settings.motionSensitivity))")
+                    .frame(width: 40, alignment: .trailing)
+                    .monospacedDigit()
+            }
+
+            MotionReadout(pipeline: pipeline)
+
+            Toggle("Enable X Motion (BETA)", isOn: $settings.xMotionEnabled)
+                .toggleStyle(.switch)
+        }
+    }
+}
+
+private struct MotionSourceRow: View {
+    let source: any MotionSource
+    @Bindable var pipeline: MotionPipeline
+
+    private var isEnabled: Bool {
+        pipeline.enabledMotionSourceIDs.contains(source.id)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Toggle(isOn: Binding(
+                get: { isEnabled },
+                set: { pipeline.setMotionSource(source.id, enabled: $0) }
+            )) {
+                Text(LocalizedStringKey(type(of: source).displayName))
+                    .font(.caption.weight(.semibold))
+            }
+            .toggleStyle(.switch)
+
+            if isEnabled {
+                if let airpods = source as? AirPodsMotionSource {
+                    AirPodsSourceDetail(source: airpods)
+                }
+            }
+        }
+    }
+}
+
+private struct DetectionSourceRow: View {
+    let source: any VehicleDetectionSource
+    @Bindable var pipeline: MotionPipeline
+
+    private var isEnabled: Bool {
+        pipeline.enabledDetectionSourceIDs.contains(source.id)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Toggle(isOn: Binding(
+                get: { isEnabled },
+                set: { pipeline.setDetectionSource(source.id, enabled: $0) }
+            )) {
+                Text(LocalizedStringKey(type(of: source).displayName))
+                    .font(.caption.weight(.semibold))
+            }
+            .toggleStyle(.switch)
+
+            if isEnabled {
+                if let location = source as? CoreLocationDetectionSource {
+                    CoreLocationSourceDetail(source: location)
+                }
+            }
+        }
+    }
+}
+
+private struct CoreLocationSourceDetail: View {
+    @Bindable var source: CoreLocationDetectionSource
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            switch source.state {
+            case .permissionNotDetermined:
+                Text("Asking for location permission…")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            case .permissionDenied, .unavailable, .error:
+                permissionDeniedView
+            case .idle, .connecting:
+                Text("Setting up…")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            case .streaming, .stale:
+                statusView
+            }
+        }
+    }
+
+    private var permissionDeniedView: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundColor(.orange)
+                Text("Location access denied")
+                    .font(.caption2.weight(.semibold))
+            }
+            Button {
+                CoreLocationDetectionSource.openSystemSettings()
+            } label: {
+                Text("Open System Settings…")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
+    }
+
+    private var statusView: some View {
+        HStack(spacing: 6) {
+            if source.inVehicle {
+                Circle().fill(Color.green).frame(width: 6, height: 6)
+                Text("In vehicle")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            } else {
+                Circle().fill(Color.secondary).frame(width: 6, height: 6)
+                Text("Stationary")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+}
+
+private struct AirPodsSourceDetail: View {
+    @Bindable var source: AirPodsMotionSource
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            switch source.state {
             case .permissionNotDetermined:
                 permissionNotDeterminedView
-            case .permissionDenied:
+            case .permissionDenied, .unavailable, .error:
                 permissionDeniedView
-            case .noAirPods:
-                noAirPodsView
+            case .idle:
+                lookingForAirPodsView
             case .connecting:
                 connectingView
-            case .streaming, .stale:
-                activeView
+            case .streaming:
+                streamingView
+            case .stale:
+                staleView
             }
         }
     }
 
     private var permissionNotDeterminedView: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Mac Motion Cues uses AirPods head-tracking to drive cue motion.")
-                .font(.caption)
+            Text("Uses AirPods head-tracking to drive cue motion.")
+                .font(.caption2)
                 .foregroundColor(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
             Button {
-                motionViewModel.requestPermission()
+                source.requestPermission()
             } label: {
                 Text("Grant Motion Access")
                     .frame(maxWidth: .infinity)
             }
             .buttonStyle(.borderedProminent)
+            .controlSize(.small)
         }
     }
 
@@ -170,19 +344,20 @@ private struct MotionStatusPanel: View {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .foregroundColor(.orange)
                 Text("Motion access denied")
-                    .font(.caption.weight(.semibold))
+                    .font(.caption2.weight(.semibold))
             }
             Text("Cues need Motion & Fitness to read AirPods movement.")
-                .font(.caption)
+                .font(.caption2)
                 .foregroundColor(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
             Button {
-                MotionViewModel.openSystemSettings()
+                AirPodsMotionSource.openSystemSettings()
             } label: {
                 Text("Open System Settings…")
                     .frame(maxWidth: .infinity)
             }
             .buttonStyle(.bordered)
+            .controlSize(.small)
             Text("You may need to relaunch the app after granting access.")
                 .font(.caption2)
                 .foregroundColor(.secondary)
@@ -190,89 +365,70 @@ private struct MotionStatusPanel: View {
         }
     }
 
-    private var noAirPodsView: some View {
-        HStack(spacing: 8) {
+    private var lookingForAirPodsView: some View {
+        HStack(spacing: 6) {
             Image(systemName: "airpods")
                 .foregroundColor(.secondary)
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Put on your AirPods")
-                    .font(.caption.weight(.semibold))
-                Text("Looking for compatible AirPods…")
-                    .font(.caption2)
-                    .foregroundColor(.secondary)
-            }
-            Spacer()
+            Text("Looking for compatible AirPods…")
+                .font(.caption2)
+                .foregroundColor(.secondary)
         }
     }
 
     private var connectingView: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: 6) {
             ProgressView()
                 .scaleEffect(0.6)
-                .frame(width: 16, height: 16)
+                .frame(width: 14, height: 14)
             Text("Connecting…")
-                .font(.caption)
-            Spacer()
+                .font(.caption2)
+                .foregroundColor(.secondary)
         }
     }
 
-    private var activeView: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            if motionViewModel.state == .stale {
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack(spacing: 6) {
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .foregroundColor(.orange)
-                        Text("AirPods went to sleep")
-                            .font(.caption.weight(.semibold))
-                    }
-                    Text("Move your head or take them out and put them back in to reconnect.")
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-            } else {
-                HStack {
-                    Image(systemName: "airpods")
-                    Text("AirPods connected")
-                        .font(.caption)
-                    Circle()
-                        .fill(Color.green)
-                        .frame(width: 8, height: 8)
-                    Spacer()
-                }
+    private var streamingView: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(Color.green)
+                .frame(width: 6, height: 6)
+            Text("AirPods connected")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+        }
+    }
+
+    private var staleView: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundColor(.orange)
+                Text("AirPods went to sleep")
+                    .font(.caption2.weight(.semibold))
             }
-
-            HStack {
-                Text("Sensitivity")
-                Slider(value: $settings.motionSensitivity, in: 1...20, step: 1)
-                Text("\(Int(settings.motionSensitivity))")
-                    .frame(width: 40, alignment: .trailing)
-                    .monospacedDigit()
-            }
-
-            MotionReadout(motionViewModel: motionViewModel)
-
-            Toggle("Enable X Motion (BETA)", isOn: $settings.xMotionEnabled)
-                .toggleStyle(.switch)
+            Text("Move your head or take them out and put them back in to reconnect.")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 }
 
 private struct MotionReadout: View {
-    @Bindable var motionViewModel: MotionViewModel
+    @Bindable var pipeline: MotionPipeline
 
     var body: some View {
+        let lateralAccel = pipeline.latestSample?.lateralAccel ?? 0
+        let longitudinalAccel = pipeline.latestSample?.longitudinalAccel ?? 0
         HStack(spacing: 16) {
             HStack(spacing: 4) {
                 Text("X:")
-                Text(String(format: "%.2f", motionViewModel.motionX))
+                Text(String(format: "%.2f", lateralAccel))
                     .monospacedDigit()
                     .frame(width: 38, alignment: .trailing)
             }
             HStack(spacing: 4) {
                 Text("Y:")
-                Text(String(format: "%.2f", motionViewModel.motionY))
+                Text(String(format: "%.2f", longitudinalAccel))
                     .monospacedDigit()
                     .frame(width: 38, alignment: .trailing)
             }

--- a/Mac Motion Cues/View/MenuBar.swift
+++ b/Mac Motion Cues/View/MenuBar.swift
@@ -132,10 +132,7 @@ struct MenuBar: View {
                                     .monospacedDigit()
                             }
 
-                            HStack {
-                                Text("X: \(String(format: "%.2f", motionViewModel.motionX))")
-                                Text("Y: \(String(format: "%.2f", motionViewModel.motionY))")
-                            }
+                            MotionReadout(motionViewModel: motionViewModel)
 
                             HStack {
                                 Toggle("Enable X Motion (BETA)", isOn: $settings.xMotionEnabled)
@@ -178,5 +175,26 @@ struct MenuBar: View {
         }
         .frame(width: 300)
         .padding(.vertical)
+    }
+}
+
+private struct MotionReadout: View {
+    @Bindable var motionViewModel: MotionViewModel
+
+    var body: some View {
+        HStack(spacing: 16) {
+            HStack(spacing: 4) {
+                Text("X:")
+                Text(String(format: "%.2f", motionViewModel.motionX))
+                    .monospacedDigit()
+                    .frame(width: 38, alignment: .trailing)
+            }
+            HStack(spacing: 4) {
+                Text("Y:")
+                Text(String(format: "%.2f", motionViewModel.motionY))
+                    .monospacedDigit()
+                    .frame(width: 38, alignment: .trailing)
+            }
+        }
     }
 }

--- a/Mac Motion Cues/View/MenuBar.swift
+++ b/Mac Motion Cues/View/MenuBar.swift
@@ -4,8 +4,8 @@ import SwiftUI
 
 struct MenuBar: View {
     @Bindable var motionViewModel: MotionViewModel
+    @Bindable var appState: AppState
     @Bindable var settings: DotsSettings
-    @AppStorage("appEnabled") private var appEnabled: Bool = true
 
     var body: some View {
         VStack(alignment: .center, spacing: 15) {
@@ -13,128 +13,87 @@ struct MenuBar: View {
                 .font(.headline)
                 .padding(.top)
 
-            Toggle("Enable Visual Cues", isOn: $appEnabled)
+            Toggle("Enable Visual Cues", isOn: $appState.appEnabled)
                 .toggleStyle(.switch)
                 .padding(.horizontal)
 
             Divider()
 
-            if appEnabled {
-                GroupBox {
-                    Text("Visual Settings")
-                        .font(.subheadline)
-                        .padding(.bottom, 5)
+            GroupBox {
+                Text("Visual Settings")
+                    .font(.subheadline)
+                    .padding(.bottom, 5)
 
-                    VStack(spacing: 10) {
-                        HStack {
-                            Text("Size")
-                            Slider(value: $settings.dotSize, in: 10...30, step: 1)
-                            Text("\(Int(settings.dotSize))")
-                                .frame(width: 40, alignment: .trailing)
-                                .monospacedDigit()
-                        }
+                VStack(spacing: 10) {
+                    HStack {
+                        Text("Size")
+                        Slider(value: $settings.dotSize, in: 10...30, step: 1)
+                        Text("\(Int(settings.dotSize))")
+                            .frame(width: 40, alignment: .trailing)
+                            .monospacedDigit()
+                    }
 
-                        HStack {
-                            Text("Spacing")
-                            Slider(
-                                value: $settings.verticalSpacing,
-                                in: 20...100,
-                                step: 5
-                            )
-                            Text("\(Int(settings.verticalSpacing))")
-                                .frame(width: 40, alignment: .trailing)
-                                .monospacedDigit()
-                        }
+                    HStack {
+                        Text("Spacing")
+                        Slider(
+                            value: $settings.verticalSpacing,
+                            in: 20...100,
+                            step: 5
+                        )
+                        Text("\(Int(settings.verticalSpacing))")
+                            .frame(width: 40, alignment: .trailing)
+                            .monospacedDigit()
                     }
                 }
-                .padding(.horizontal)
-
-                Divider()
-
-                GroupBox {
-                    Text("Dot Style")
-                        .font(.subheadline)
-                        .padding(.bottom, 5)
-
-                    VStack(alignment: .leading, spacing: 10) {
-                        HStack {
-                            Text("Style")
-                                .frame(width: 50, alignment: .leading)
-                            Picker("Style", selection: $settings.dotStyle) {
-                                Text("Solid").tag(DotStyle.solid)
-                                Text("Dynamic").tag(DotStyle.dynamic)
-                            }
-                            .pickerStyle(.segmented)
-                            .labelsHidden()
-                        }
-
-                        HStack {
-                            Text("Halo")
-                                .frame(width: 50, alignment: .leading)
-                            Picker("Halo", selection: $settings.haloStyle) {
-                                Text("Off").tag(HaloStyle.off)
-                                Text("Solid").tag(HaloStyle.solid)
-                                Text("Dynamic").tag(HaloStyle.dynamic)
-                            }
-                            .pickerStyle(.segmented)
-                            .labelsHidden()
-                        }
-                    }
-                }
-                .padding(.horizontal)
-
-                Divider()
-
-                GroupBox {
-                    Text("Motion Settings")
-                        .font(.subheadline)
-                        .padding(.bottom, 5)
-
-                    VStack(spacing: 10) {
-                        Button {
-                            Task {
-                                if motionViewModel.isMotionEnabled {
-                                    motionViewModel.stopDeviceMotion()
-                                } else {
-                                    try await motionViewModel.startDeviceMotion()
-                                }
-                            }
-                        } label: {
-                            Text(motionViewModel.isMotionEnabled ? "Disable Motion" : "Enable Motion")
-                                .frame(maxWidth: .infinity)
-                        }
-                        .buttonStyle(.borderedProminent)
-
-                        if motionViewModel.isMotionEnabled {
-                            HStack {
-                                Image(systemName: "airpods")
-                                Text("AirPods connected")
-                                Circle()
-                                    .fill(Color.green)
-                                    .frame(width: 8, height: 8)
-                            }
-
-                            HStack {
-                                Text("Sensitivity")
-                                Slider(value: $settings.motionSensitivity, in: 1...20, step: 1)
-                                Text("\(Int(settings.motionSensitivity))")
-                                    .frame(width: 40, alignment: .trailing)
-                                    .monospacedDigit()
-                            }
-
-                            MotionReadout(motionViewModel: motionViewModel)
-
-                            HStack {
-                                Toggle("Enable X Motion (BETA)", isOn: $settings.xMotionEnabled)
-                                    .toggleStyle(.switch)
-                            }
-                        }
-                    }
-                }
-                .padding(.horizontal)
-
-                Divider()
             }
+            .padding(.horizontal)
+
+            Divider()
+
+            GroupBox {
+                Text("Dot Style")
+                    .font(.subheadline)
+                    .padding(.bottom, 5)
+
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack {
+                        Text("Style")
+                            .frame(width: 50, alignment: .leading)
+                        Picker("Style", selection: $settings.dotStyle) {
+                            Text("Solid").tag(DotStyle.solid)
+                            Text("Dynamic").tag(DotStyle.dynamic)
+                        }
+                        .pickerStyle(.segmented)
+                        .labelsHidden()
+                    }
+
+                    HStack {
+                        Text("Halo")
+                            .frame(width: 50, alignment: .leading)
+                        Picker("Halo", selection: $settings.haloStyle) {
+                            Text("Off").tag(HaloStyle.off)
+                            Text("Solid").tag(HaloStyle.solid)
+                            Text("Dynamic").tag(HaloStyle.dynamic)
+                        }
+                        .pickerStyle(.segmented)
+                        .labelsHidden()
+                    }
+                }
+            }
+            .padding(.horizontal)
+
+            Divider()
+
+            GroupBox {
+                Text("Motion Settings")
+                    .font(.subheadline)
+                    .padding(.bottom, 5)
+
+                MotionStatusPanel(motionViewModel: motionViewModel, settings: settings)
+            }
+            .padding(.horizontal)
+
+            Divider()
 
             GroupBox {
                 VStack(alignment: .center, spacing: 5) {
@@ -165,6 +124,138 @@ struct MenuBar: View {
         }
         .frame(width: 300)
         .padding(.vertical)
+    }
+}
+
+private struct MotionStatusPanel: View {
+    @Bindable var motionViewModel: MotionViewModel
+    @Bindable var settings: DotsSettings
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            switch motionViewModel.state {
+            case .permissionNotDetermined:
+                permissionNotDeterminedView
+            case .permissionDenied:
+                permissionDeniedView
+            case .noAirPods:
+                noAirPodsView
+            case .connecting:
+                connectingView
+            case .streaming, .stale:
+                activeView
+            }
+        }
+    }
+
+    private var permissionNotDeterminedView: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Mac Motion Cues uses AirPods head-tracking to drive cue motion.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Button {
+                motionViewModel.requestPermission()
+            } label: {
+                Text("Grant Motion Access")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+        }
+    }
+
+    private var permissionDeniedView: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 6) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundColor(.orange)
+                Text("Motion access denied")
+                    .font(.caption.weight(.semibold))
+            }
+            Text("Cues need Motion & Fitness to read AirPods movement.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Button {
+                MotionViewModel.openSystemSettings()
+            } label: {
+                Text("Open System Settings…")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+            Text("You may need to relaunch the app after granting access.")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var noAirPodsView: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "airpods")
+                .foregroundColor(.secondary)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Put on your AirPods")
+                    .font(.caption.weight(.semibold))
+                Text("Looking for compatible AirPods…")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+            Spacer()
+        }
+    }
+
+    private var connectingView: some View {
+        HStack(spacing: 8) {
+            ProgressView()
+                .scaleEffect(0.6)
+                .frame(width: 16, height: 16)
+            Text("Connecting…")
+                .font(.caption)
+            Spacer()
+        }
+    }
+
+    private var activeView: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if motionViewModel.state == .stale {
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundColor(.orange)
+                        Text("AirPods went to sleep")
+                            .font(.caption.weight(.semibold))
+                    }
+                    Text("Move your head or take them out and put them back in to reconnect.")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            } else {
+                HStack {
+                    Image(systemName: "airpods")
+                    Text("AirPods connected")
+                        .font(.caption)
+                    Circle()
+                        .fill(Color.green)
+                        .frame(width: 8, height: 8)
+                    Spacer()
+                }
+            }
+
+            HStack {
+                Text("Sensitivity")
+                Slider(value: $settings.motionSensitivity, in: 1...20, step: 1)
+                Text("\(Int(settings.motionSensitivity))")
+                    .frame(width: 40, alignment: .trailing)
+                    .monospacedDigit()
+            }
+
+            MotionReadout(motionViewModel: motionViewModel)
+
+            Toggle("Enable X Motion (BETA)", isOn: $settings.xMotionEnabled)
+                .toggleStyle(.switch)
+        }
     }
 }
 

--- a/Mac Motion Cues/View/OverlayWindowController.swift
+++ b/Mac Motion Cues/View/OverlayWindowController.swift
@@ -12,6 +12,34 @@ final class OverlayWindowController {
     private var observer: NSObjectProtocol?
     private(set) var isInstalled = false
 
+    /// Drives `install()`/`uninstall()` reactively from `appState.appEnabled`
+    /// and `motionViewModel.state`, independent of any view's lifecycle.
+    /// Call once at app launch; re-arms itself after each mutation.
+    func startObservingMountConditions(appState: AppState, motionViewModel: MotionViewModel) {
+        observeMountConditions(appState: appState, motionViewModel: motionViewModel)
+    }
+
+    private func observeMountConditions(appState: AppState, motionViewModel: MotionViewModel) {
+        withObservationTracking {
+            _ = appState.appEnabled
+            _ = motionViewModel.state
+        } onChange: { [weak self] in
+            Task { @MainActor in
+                self?.applyMountState(appState: appState, motionViewModel: motionViewModel)
+                self?.observeMountConditions(appState: appState, motionViewModel: motionViewModel)
+            }
+        }
+        applyMountState(appState: appState, motionViewModel: motionViewModel)
+    }
+
+    private func applyMountState(appState: AppState, motionViewModel: MotionViewModel) {
+        if appState.appEnabled && motionViewModel.state == .streaming {
+            install()
+        } else {
+            uninstall()
+        }
+    }
+
     func install() {
         guard !isInstalled else { return }
         isInstalled = true

--- a/Mac Motion Cues/View/OverlayWindowController.swift
+++ b/Mac Motion Cues/View/OverlayWindowController.swift
@@ -13,27 +13,26 @@ final class OverlayWindowController {
     private(set) var isInstalled = false
 
     /// Drives `install()`/`uninstall()` reactively from `appState.appEnabled`
-    /// and `motionViewModel.state`, independent of any view's lifecycle.
+    /// and `pipeline.shouldRenderCues`, independent of any view's lifecycle.
     /// Call once at app launch; re-arms itself after each mutation.
-    func startObservingMountConditions(appState: AppState, motionViewModel: MotionViewModel) {
-        observeMountConditions(appState: appState, motionViewModel: motionViewModel)
+    func startObservingMountConditions(appState: AppState, pipeline: MotionPipeline) {
+        observeMountConditions(appState: appState, pipeline: pipeline)
     }
 
-    private func observeMountConditions(appState: AppState, motionViewModel: MotionViewModel) {
+    private func observeMountConditions(appState: AppState, pipeline: MotionPipeline) {
         withObservationTracking {
-            _ = appState.appEnabled
-            _ = motionViewModel.state
+            _ = pipeline.shouldRenderCues(appEnabled: appState.appEnabled)
         } onChange: { [weak self] in
             Task { @MainActor in
-                self?.applyMountState(appState: appState, motionViewModel: motionViewModel)
-                self?.observeMountConditions(appState: appState, motionViewModel: motionViewModel)
+                self?.applyMountState(appState: appState, pipeline: pipeline)
+                self?.observeMountConditions(appState: appState, pipeline: pipeline)
             }
         }
-        applyMountState(appState: appState, motionViewModel: motionViewModel)
+        applyMountState(appState: appState, pipeline: pipeline)
     }
 
-    private func applyMountState(appState: AppState, motionViewModel: MotionViewModel) {
-        if appState.appEnabled && motionViewModel.state == .streaming {
+    private func applyMountState(appState: AppState, pipeline: MotionPipeline) {
+        if pipeline.shouldRenderCues(appEnabled: appState.appEnabled) {
             install()
         } else {
             uninstall()
@@ -121,7 +120,7 @@ final class OverlayWindowController {
         let host = NSHostingView(
             rootView: DotsView(
                 dotsViewModel: viewModel,
-                motionViewModel: MotionViewModel.shared
+                pipeline: MotionPipeline.shared
             )
         )
         host.frame = NSRect(origin: .zero, size: screen.frame.size)

--- a/Mac Motion Cues/View/OverlayWindowController.swift
+++ b/Mac Motion Cues/View/OverlayWindowController.swift
@@ -1,0 +1,118 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class OverlayWindowController {
+    private struct Entry {
+        let window: NSWindow
+        let viewModel: DotsViewModel
+    }
+
+    private var entries: [CGDirectDisplayID: Entry] = [:]
+    private var observer: NSObjectProtocol?
+    private(set) var isInstalled = false
+
+    func install() {
+        guard !isInstalled else { return }
+        isInstalled = true
+        sync()
+        observer = NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.sync() }
+        }
+    }
+
+    func uninstall() {
+        guard isInstalled else { return }
+        isInstalled = false
+        if let observer {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        observer = nil
+        let windowsToClose = Array(entries.values)
+        entries.removeAll()
+        for entry in windowsToClose {
+            entry.window.orderOut(nil)
+            entry.window.close()
+        }
+    }
+
+    func notifySettingsChanged() {
+        for entry in entries.values {
+            entry.viewModel.updateSpacing()
+        }
+    }
+
+    private func sync() {
+        var current: [CGDirectDisplayID: NSScreen] = [:]
+        for screen in NSScreen.screens {
+            if let id = screen.displayID {
+                current[id] = screen
+            }
+        }
+
+        let staleIDs = entries.keys.filter { current[$0] == nil }
+        for id in staleIDs {
+            if let entry = entries.removeValue(forKey: id) {
+                entry.window.orderOut(nil)
+                entry.window.close()
+            }
+        }
+
+        for (id, screen) in current {
+            if let entry = entries[id] {
+                if entry.window.frame != screen.frame {
+                    entry.window.setFrame(screen.frame, display: true)
+                }
+            } else {
+                entries[id] = makeEntry(for: screen)
+            }
+        }
+    }
+
+    private func makeEntry(for screen: NSScreen) -> Entry {
+        let window = NSWindow(
+            contentRect: screen.frame,
+            styleMask: [.borderless, .fullSizeContentView],
+            backing: .buffered,
+            defer: false,
+            screen: screen
+        )
+        window.isReleasedWhenClosed = false
+        window.backgroundColor = .clear
+        window.isOpaque = false
+        window.level = .floating
+        window.ignoresMouseEvents = true
+        window.isMovableByWindowBackground = false
+        window.hasShadow = false
+        window.titleVisibility = .hidden
+        window.titlebarAppearsTransparent = true
+        window.standardWindowButton(.closeButton)?.isHidden = true
+        window.standardWindowButton(.miniaturizeButton)?.isHidden = true
+        window.standardWindowButton(.zoomButton)?.isHidden = true
+        window.collectionBehavior = [.canJoinAllSpaces, .stationary, .ignoresCycle]
+
+        let viewModel = DotsViewModel()
+        let host = NSHostingView(
+            rootView: DotsView(
+                dotsViewModel: viewModel,
+                motionViewModel: MotionViewModel.shared
+            )
+        )
+        host.frame = NSRect(origin: .zero, size: screen.frame.size)
+        host.autoresizingMask = [.width, .height]
+        window.contentView = host
+        window.orderFrontRegardless()
+
+        return Entry(window: window, viewModel: viewModel)
+    }
+}
+
+private extension NSScreen {
+    var displayID: CGDirectDisplayID? {
+        deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID
+    }
+}

--- a/Mac Motion Cues/View/OverlayWindowController.swift
+++ b/Mac Motion Cues/View/OverlayWindowController.swift
@@ -40,12 +40,6 @@ final class OverlayWindowController {
         }
     }
 
-    func notifySettingsChanged() {
-        for entry in entries.values {
-            entry.viewModel.updateSpacing()
-        }
-    }
-
     private func sync() {
         var current: [CGDirectDisplayID: NSScreen] = [:]
         for screen in NSScreen.screens {

--- a/Mac Motion Cues/ViewModel/AppState.swift
+++ b/Mac Motion Cues/ViewModel/AppState.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+@Observable
+final class AppState {
+    static let shared = AppState()
+
+    var appEnabled: Bool {
+        didSet { defaults.set(appEnabled, forKey: Keys.appEnabled) }
+    }
+
+    private let defaults = UserDefaults.standard
+    private enum Keys {
+        static let appEnabled = "appEnabled"
+    }
+
+    private init() {
+        defaults.register(defaults: [Keys.appEnabled: true])
+        appEnabled = defaults.bool(forKey: Keys.appEnabled)
+    }
+}

--- a/Mac Motion Cues/ViewModel/DotsSettings.swift
+++ b/Mac Motion Cues/ViewModel/DotsSettings.swift
@@ -1,19 +1,57 @@
 import Foundation
 import SwiftUI
 
+enum DotStyle: String, CaseIterable {
+    case solid
+    case dynamic
+}
+
+enum HaloStyle: String, CaseIterable {
+    case off
+    case solid
+    case dynamic
+}
+
 @Observable
 final class DotsSettings {
     static let shared = DotsSettings()
 
-    var dotSize: CGFloat = 30
-    var verticalSpacing: CGFloat = 50
-    var motionSensitivity: CGFloat = 10.0
-    var xMotionEnabled: Bool = false
+    var dotSize: CGFloat            { didSet { defaults.set(Double(dotSize), forKey: Keys.dotSize) } }
+    var verticalSpacing: CGFloat    { didSet { defaults.set(Double(verticalSpacing), forKey: Keys.verticalSpacing) } }
+    var motionSensitivity: CGFloat  { didSet { defaults.set(Double(motionSensitivity), forKey: Keys.motionSensitivity) } }
+    var xMotionEnabled: Bool        { didSet { defaults.set(xMotionEnabled, forKey: Keys.xMotionEnabled) } }
+    var dotStyle: DotStyle          { didSet { defaults.set(dotStyle.rawValue, forKey: Keys.dotStyle) } }
+    var haloStyle: HaloStyle        { didSet { defaults.set(haloStyle.rawValue, forKey: Keys.haloStyle) } }
 
     let leftBound: CGFloat = -300
     let rightBound: CGFloat = 300
 
-    private init() {}
+    private let defaults = UserDefaults.standard
+    private enum Keys {
+        static let dotSize = "dotSize"
+        static let verticalSpacing = "verticalSpacing"
+        static let motionSensitivity = "motionSensitivity"
+        static let xMotionEnabled = "xMotionEnabled"
+        static let dotStyle = "dotStyle"
+        static let haloStyle = "haloStyle"
+    }
+
+    private init() {
+        defaults.register(defaults: [
+            Keys.dotSize: 30.0,
+            Keys.verticalSpacing: 50.0,
+            Keys.motionSensitivity: 10.0,
+            Keys.xMotionEnabled: false,
+            Keys.dotStyle: DotStyle.dynamic.rawValue,
+            Keys.haloStyle: HaloStyle.dynamic.rawValue,
+        ])
+        dotSize = CGFloat(defaults.double(forKey: Keys.dotSize))
+        verticalSpacing = CGFloat(defaults.double(forKey: Keys.verticalSpacing))
+        motionSensitivity = CGFloat(defaults.double(forKey: Keys.motionSensitivity))
+        xMotionEnabled = defaults.bool(forKey: Keys.xMotionEnabled)
+        dotStyle = DotStyle(rawValue: defaults.string(forKey: Keys.dotStyle) ?? "") ?? .dynamic
+        haloStyle = HaloStyle(rawValue: defaults.string(forKey: Keys.haloStyle) ?? "") ?? .dynamic
+    }
 
     func ensureSpacingFitsSize() {
         if verticalSpacing < dotSize * 1.5 {

--- a/Mac Motion Cues/ViewModel/DotsSettings.swift
+++ b/Mac Motion Cues/ViewModel/DotsSettings.swift
@@ -1,0 +1,23 @@
+import Foundation
+import SwiftUI
+
+@Observable
+final class DotsSettings {
+    static let shared = DotsSettings()
+
+    var dotSize: CGFloat = 30
+    var verticalSpacing: CGFloat = 50
+    var motionSensitivity: CGFloat = 10.0
+    var xMotionEnabled: Bool = false
+
+    let leftBound: CGFloat = -300
+    let rightBound: CGFloat = 300
+
+    private init() {}
+
+    func ensureSpacingFitsSize() {
+        if verticalSpacing < dotSize * 1.5 {
+            verticalSpacing = dotSize * 1.5
+        }
+    }
+}

--- a/Mac Motion Cues/ViewModel/DotsSettings.swift
+++ b/Mac Motion Cues/ViewModel/DotsSettings.swift
@@ -16,7 +16,14 @@ enum HaloStyle: String, CaseIterable {
 final class DotsSettings {
     static let shared = DotsSettings()
 
-    var dotSize: CGFloat            { didSet { defaults.set(Double(dotSize), forKey: Keys.dotSize) } }
+    var dotSize: CGFloat {
+        didSet {
+            defaults.set(Double(dotSize), forKey: Keys.dotSize)
+            if verticalSpacing < dotSize * 1.5 {
+                verticalSpacing = dotSize * 1.5
+            }
+        }
+    }
     var verticalSpacing: CGFloat    { didSet { defaults.set(Double(verticalSpacing), forKey: Keys.verticalSpacing) } }
     var motionSensitivity: CGFloat  { didSet { defaults.set(Double(motionSensitivity), forKey: Keys.motionSensitivity) } }
     var xMotionEnabled: Bool        { didSet { defaults.set(xMotionEnabled, forKey: Keys.xMotionEnabled) } }
@@ -53,9 +60,4 @@ final class DotsSettings {
         haloStyle = HaloStyle(rawValue: defaults.string(forKey: Keys.haloStyle) ?? "") ?? .dynamic
     }
 
-    func ensureSpacingFitsSize() {
-        if verticalSpacing < dotSize * 1.5 {
-            verticalSpacing = dotSize * 1.5
-        }
-    }
 }

--- a/Mac Motion Cues/ViewModel/DotsViewModel.swift
+++ b/Mac Motion Cues/ViewModel/DotsViewModel.swift
@@ -1,4 +1,3 @@
-import Combine
 import Foundation
 import SwiftUI
 
@@ -21,8 +20,6 @@ class DotsViewModel {
     private var screenWidth: CGFloat = 800
 
     private var lastUpdateTime: TimeInterval = CACurrentMediaTime()
-
-    private var cancellables = Set<AnyCancellable>()
 
     init() {}
 
@@ -58,36 +55,37 @@ class DotsViewModel {
     }
 
     func updateSpacing() {
-        dots = stride(from: 0, through: screenHeight, by: verticalSpacing).map { y in
-            let existingDot = dots.first {
-                abs($0.offsetY - (screenHeight - y)) < verticalSpacing / 2
-            }
+        let positions = Array(stride(from: 0, through: screenHeight, by: verticalSpacing))
+        let targetCount = positions.count
 
-            return Dot(
-                offsetY: screenHeight - y,
-                offsetX: existingDot?.offsetX ?? 0,
-                size: dotSize
-            )
+        // Reuse existing dots (preserving identity) and adjust count as needed
+        while dots.count > targetCount {
+            dots.removeLast()
+        }
+        while dots.count < targetCount {
+            dots.append(Dot(offsetY: 0, offsetX: 0, size: dotSize))
+        }
+
+        for (i, y) in positions.enumerated() {
+            dots[i].offsetY = screenHeight - y
+            dots[i].size = dotSize
         }
     }
 
     func updateDotsPosition() {
-        if !MotionViewModel.shared.isMotionEnabled {
-            return
-        }
         guard MotionViewModel.shared.isMotionEnabled else { return }
 
         let fixedDeltaTime: CGFloat = 1.0 / 60.0
 
         let motionX = CGFloat(MotionViewModel.shared.motionX)
+        let motionY = CGFloat(MotionViewModel.shared.motionY)
 
         let isXMotionRelevant = abs(motionX) > 0.02
-
-        let motionY = CGFloat(MotionViewModel.shared.motionY)
+        let isYMotionRelevant = abs(motionY) > 0.02
 
         var baseSpeedY: CGFloat = 0
         var xInfluence: CGFloat = 0
-        let isYMotionRelevant = abs(motionY) > 0.02
+
         if isYMotionRelevant {
             baseSpeedY = 200 * fixedDeltaTime * motionY * motionSensitivity
         }
@@ -97,6 +95,14 @@ class DotsViewModel {
         }
 
         let boundWidth = rightBound - leftBound
+
+        // Pre-compute min/max Y once before the loop instead of per-wrapping-dot
+        var maxY = -CGFloat.greatestFiniteMagnitude
+        var minY = CGFloat.greatestFiniteMagnitude
+        for dot in dots {
+            if dot.offsetY > maxY { maxY = dot.offsetY }
+            if dot.offsetY < minY { minY = dot.offsetY }
+        }
 
         for index in dots.indices {
             if isXMotionRelevant {
@@ -113,17 +119,9 @@ class DotsViewModel {
                 dots[index].offsetY -= baseSpeedY
 
                 if dots[index].offsetY <= -dotSize {
-                    if let lowestDotY = dots.max(by: { $0.offsetY < $1.offsetY })?.offsetY {
-                        dots[index].offsetY = lowestDotY + verticalSpacing
-                    } else {
-                        dots[index].offsetY = screenHeight + verticalSpacing
-                    }
+                    dots[index].offsetY = maxY + verticalSpacing
                 } else if dots[index].offsetY > screenHeight + verticalSpacing {
-                    if let highestDotY = dots.min(by: { $0.offsetY < $1.offsetY })?.offsetY {
-                        dots[index].offsetY = highestDotY - verticalSpacing
-                    } else {
-                        dots[index].offsetY = -dotSize
-                    }
+                    dots[index].offsetY = minY - verticalSpacing
                 }
             }
         }

--- a/Mac Motion Cues/ViewModel/DotsViewModel.swift
+++ b/Mac Motion Cues/ViewModel/DotsViewModel.swift
@@ -69,13 +69,14 @@ class DotsViewModel {
     }
 
     func updateDotsPosition() {
-        guard MotionViewModel.shared.isStreaming else { return }
+        guard let sample = MotionPipeline.shared.latestSample,
+              MotionPipeline.shared.isStreaming else { return }
 
         let settings = DotsSettings.shared
         let fixedDeltaTime: CGFloat = 1.0 / 60.0
 
-        let motionX = CGFloat(MotionViewModel.shared.motionX)
-        let motionY = CGFloat(MotionViewModel.shared.motionY)
+        let motionX = CGFloat(sample.lateralAccel)
+        let motionY = CGFloat(sample.longitudinalAccel)
 
         let isXMotionRelevant = abs(motionX) > 0.02
         let isYMotionRelevant = abs(motionY) > 0.02

--- a/Mac Motion Cues/ViewModel/DotsViewModel.swift
+++ b/Mac Motion Cues/ViewModel/DotsViewModel.swift
@@ -4,58 +4,32 @@ import SwiftUI
 @Observable
 class DotsViewModel {
     var dots: [Dot] = []
-    var dotSize: CGFloat = 30
-    var verticalSpacing: CGFloat = 50
-    var speedY: CGFloat = 0.5
-    var speedX: CGFloat = 0.5
-    var motionSensitivity: CGFloat = 10.0
-    var xMotionEnabled: Bool = false
-
-    let leftBound: CGFloat = -300
-    let rightBound: CGFloat = 300
-
-    static let shared = DotsViewModel()
 
     private var screenHeight: CGFloat = 200
-    private var screenWidth: CGFloat = 800
-
     private var lastUpdateTime: TimeInterval = CACurrentMediaTime()
 
     init() {}
 
-    func updateXMotionEnabled(_ enabled: Bool) {
-        xMotionEnabled = enabled
-    }
-
-    func initializeDots(screenHeight: CGFloat, screenWidth: CGFloat = 800) {
+    func initializeDots(screenHeight: CGFloat) {
         self.screenHeight = screenHeight
-        self.screenWidth = screenWidth
 
-        let positions = stride(from: 0, through: screenHeight, by: verticalSpacing)
+        let settings = DotsSettings.shared
+        let positions = balancedPositions(screenHeight: screenHeight, spacing: settings.verticalSpacing)
 
         var newDots: [Dot] = []
-
-        for (index, y) in positions.enumerated() {
-            let dot = Dot(
+        for y in positions {
+            newDots.append(Dot(
                 offsetY: screenHeight - y,
-                offsetX: index % 2 == 0 ? 100 : screenWidth - 100,
-                size: dotSize
-            )
-            newDots.append(dot)
+                offsetX: 0,
+                size: settings.dotSize
+            ))
         }
-
         dots = newDots
     }
 
-    func updateDotSize() {
-        if verticalSpacing < dotSize * 1.5 {
-            verticalSpacing = dotSize * 1.5
-        }
-        updateSpacing()
-    }
-
     func updateSpacing() {
-        let positions = Array(stride(from: 0, through: screenHeight, by: verticalSpacing))
+        let settings = DotsSettings.shared
+        let positions = balancedPositions(screenHeight: screenHeight, spacing: settings.verticalSpacing)
         let targetCount = positions.count
 
         // Reuse existing dots (preserving identity) and adjust count as needed
@@ -63,18 +37,27 @@ class DotsViewModel {
             dots.removeLast()
         }
         while dots.count < targetCount {
-            dots.append(Dot(offsetY: 0, offsetX: 0, size: dotSize))
+            dots.append(Dot(offsetY: 0, offsetX: 0, size: settings.dotSize))
         }
 
         for (i, y) in positions.enumerated() {
             dots[i].offsetY = screenHeight - y
-            dots[i].size = dotSize
+            dots[i].size = settings.dotSize
         }
+    }
+
+    // Produces an even number of Y stops so the left/right column counts
+    // (derived from `index % 2` in DotsView) always match.
+    private func balancedPositions(screenHeight: CGFloat, spacing: CGFloat) -> [CGFloat] {
+        var positions = Array(stride(from: 0, through: screenHeight, by: spacing))
+        if positions.count % 2 != 0 { positions.removeLast() }
+        return positions
     }
 
     func updateDotsPosition() {
         guard MotionViewModel.shared.isMotionEnabled else { return }
 
+        let settings = DotsSettings.shared
         let fixedDeltaTime: CGFloat = 1.0 / 60.0
 
         let motionX = CGFloat(MotionViewModel.shared.motionX)
@@ -83,20 +66,38 @@ class DotsViewModel {
         let isXMotionRelevant = abs(motionX) > 0.02
         let isYMotionRelevant = abs(motionY) > 0.02
 
-        var baseSpeedY: CGFloat = 0
-        var xInfluence: CGFloat = 0
+        if !isXMotionRelevant && !isYMotionRelevant { return }
 
-        if isYMotionRelevant {
-            baseSpeedY = 200 * fixedDeltaTime * motionY * motionSensitivity
-        }
+        let baseSpeedY: CGFloat = isYMotionRelevant
+            ? 200 * fixedDeltaTime * motionY * settings.motionSensitivity
+            : 0
+        let xInfluence: CGFloat = (isXMotionRelevant && settings.xMotionEnabled)
+            ? 200 * fixedDeltaTime * motionX * settings.motionSensitivity
+            : 0
 
-        if isXMotionRelevant, xMotionEnabled {
-            xInfluence = 200 * fixedDeltaTime * motionX * motionSensitivity
-        }
-
+        let leftBound = settings.leftBound
+        let rightBound = settings.rightBound
         let boundWidth = rightBound - leftBound
 
-        // Pre-compute min/max Y once before the loop instead of per-wrapping-dot
+        // Pass 1: apply per-frame motion (no wraps yet — wrap targets must
+        // see consistent post-move state across all dots).
+        for index in dots.indices {
+            if isXMotionRelevant {
+                dots[index].offsetX += xInfluence
+                if dots[index].offsetX < leftBound {
+                    dots[index].offsetX = rightBound - (leftBound - dots[index].offsetX).truncatingRemainder(dividingBy: boundWidth)
+                } else if dots[index].offsetX > rightBound {
+                    dots[index].offsetX = leftBound + (dots[index].offsetX - rightBound).truncatingRemainder(dividingBy: boundWidth)
+                }
+            }
+            if isYMotionRelevant {
+                dots[index].offsetY -= baseSpeedY
+            }
+        }
+
+        guard isYMotionRelevant else { return }
+
+        // Pass 2: measure post-move column extents.
         var maxY = -CGFloat.greatestFiniteMagnitude
         var minY = CGFloat.greatestFiniteMagnitude
         for dot in dots {
@@ -104,25 +105,22 @@ class DotsViewModel {
             if dot.offsetY < minY { minY = dot.offsetY }
         }
 
+        // Pass 3: wrap dots that crossed bounds. Update running max/min so
+        // multiple wraps in the same frame land at consecutive positions
+        // instead of stacking at the same Y.
+        let dotSize = settings.dotSize
+        let spacing = settings.verticalSpacing
+        let topBound = screenHeight + spacing
+
         for index in dots.indices {
-            if isXMotionRelevant {
-                dots[index].offsetX += xInfluence
-
-                if dots[index].offsetX < leftBound {
-                    dots[index].offsetX = rightBound - (leftBound - dots[index].offsetX).truncatingRemainder(dividingBy: boundWidth)
-                } else if dots[index].offsetX > rightBound {
-                    dots[index].offsetX = leftBound + (dots[index].offsetX - rightBound).truncatingRemainder(dividingBy: boundWidth)
-                }
-            }
-
-            if isYMotionRelevant {
-                dots[index].offsetY -= baseSpeedY
-
-                if dots[index].offsetY <= -dotSize {
-                    dots[index].offsetY = maxY + verticalSpacing
-                } else if dots[index].offsetY > screenHeight + verticalSpacing {
-                    dots[index].offsetY = minY - verticalSpacing
-                }
+            if dots[index].offsetY <= -dotSize {
+                let newY = maxY + spacing
+                dots[index].offsetY = newY
+                maxY = newY
+            } else if dots[index].offsetY > topBound {
+                let newY = minY - spacing
+                dots[index].offsetY = newY
+                minY = newY
             }
         }
     }

--- a/Mac Motion Cues/ViewModel/DotsViewModel.swift
+++ b/Mac Motion Cues/ViewModel/DotsViewModel.swift
@@ -8,7 +8,21 @@ class DotsViewModel {
     private var screenHeight: CGFloat = 200
     private var lastUpdateTime: TimeInterval = CACurrentMediaTime()
 
-    init() {}
+    init() {
+        observeSpacingSettings()
+    }
+
+    private func observeSpacingSettings() {
+        withObservationTracking {
+            _ = DotsSettings.shared.verticalSpacing
+            _ = DotsSettings.shared.dotSize
+        } onChange: { [weak self] in
+            Task { @MainActor in
+                self?.updateSpacing()
+                self?.observeSpacingSettings()
+            }
+        }
+    }
 
     func initializeDots(screenHeight: CGFloat) {
         self.screenHeight = screenHeight

--- a/Mac Motion Cues/ViewModel/DotsViewModel.swift
+++ b/Mac Motion Cues/ViewModel/DotsViewModel.swift
@@ -69,7 +69,7 @@ class DotsViewModel {
     }
 
     func updateDotsPosition() {
-        guard MotionViewModel.shared.isMotionEnabled else { return }
+        guard MotionViewModel.shared.isStreaming else { return }
 
         let settings = DotsSettings.shared
         let fixedDeltaTime: CGFloat = 1.0 / 60.0

--- a/Mac Motion Cues/ViewModel/MotionViewModel.swift
+++ b/Mac Motion Cues/ViewModel/MotionViewModel.swift
@@ -1,4 +1,3 @@
-import Combine
 import CoreMotion
 
 @Observable
@@ -13,8 +12,6 @@ class MotionViewModel {
     
     private var motion = CMHeadphoneMotionManager()
     private var motionQueue = OperationQueue()
-    private var cancellables = Set<AnyCancellable>()
-    
     init() {
         motionQueue.name = "MotionQueue"
         motionQueue.qualityOfService = .userInteractive
@@ -50,6 +47,5 @@ class MotionViewModel {
     
     deinit {
         stopDeviceMotion()
-        cancellables.forEach { $0.cancel() }
     }
 }

--- a/Mac Motion Cues/ViewModel/MotionViewModel.swift
+++ b/Mac Motion Cues/ViewModel/MotionViewModel.swift
@@ -5,9 +5,7 @@ class MotionViewModel {
     var isMotionEnabled: Bool = false
     var motionX: Double = 0.0
     var motionY: Double = 0.0
-    
-    var motionSensitivity: Double = 1.0
-    
+
     static let shared = MotionViewModel()
     
     private var motion = CMHeadphoneMotionManager()

--- a/Mac Motion Cues/ViewModel/MotionViewModel.swift
+++ b/Mac Motion Cues/ViewModel/MotionViewModel.swift
@@ -1,49 +1,192 @@
+import AppKit
 import CoreMotion
+import Foundation
+
+enum MotionState: Equatable {
+    case permissionNotDetermined
+    case permissionDenied
+    case noAirPods
+    case connecting
+    case streaming
+    case stale
+}
 
 @Observable
-class MotionViewModel {
-    var isMotionEnabled: Bool = false
+final class MotionViewModel: NSObject, CMHeadphoneMotionManagerDelegate {
+    static let shared = MotionViewModel()
+
+    var state: MotionState = .permissionNotDetermined
     var motionX: Double = 0.0
     var motionY: Double = 0.0
 
-    static let shared = MotionViewModel()
-    
-    private var motion = CMHeadphoneMotionManager()
-    private var motionQueue = OperationQueue()
-    init() {
-        motionQueue.name = "MotionQueue"
-        motionQueue.qualityOfService = .userInteractive
+    var isStreaming: Bool { state == .streaming }
+
+    private let motion = CMHeadphoneMotionManager()
+    private let motionQueue: OperationQueue = {
+        let q = OperationQueue()
+        q.name = "MotionQueue"
+        q.qualityOfService = .userInteractive
+        return q
+    }()
+
+    private var staleTimer: Timer?
+    private let staleThreshold: TimeInterval = 5.0
+
+    override init() {
+        super.init()
+        motion.delegate = self
     }
-    
-    func startDeviceMotion() async throws {
-        guard !isMotionEnabled else { return }
-        
-        if motion.isDeviceMotionAvailable {
-            motion.startDeviceMotionUpdates(to: motionQueue) { [weak self] motion, error in
-                guard let self = self, let motion = motion else {
-                    if let error = error {
-                        print("Motion error: \(error.localizedDescription)")
-                    }
-                    return
-                }
-                
-                DispatchQueue.main.async {
-                    self.isMotionEnabled = true
-                    self.motionX = motion.userAcceleration.x
-                    self.motionY = motion.userAcceleration.y
-                }
+
+    func bootstrap() {
+        applyAuthorizationStatus()
+    }
+
+    func requestPermission() {
+        // First call to startDeviceMotionUpdates triggers the OS prompt when
+        // status is .notDetermined. The sample handler resolves the next
+        // state once the user accepts/denies.
+        motion.startDeviceMotionUpdates(to: motionQueue) { [weak self] sample, error in
+            guard let self else { return }
+            DispatchQueue.main.async {
+                self.handleStreamCallback(sample: sample, error: error)
             }
-        } else {
-            print("Device motion is not available")
         }
     }
-    
-    func stopDeviceMotion() {
-        motion.stopDeviceMotionUpdates()
-        isMotionEnabled = false
+
+    static func openSystemSettings() {
+        let primary = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Motion")!
+        if NSWorkspace.shared.open(primary) { return }
+        if let fallback = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy") {
+            NSWorkspace.shared.open(fallback)
+        }
     }
-    
-    deinit {
-        stopDeviceMotion()
+
+    // MARK: - State transitions
+
+    private func applyAuthorizationStatus() {
+        switch CMHeadphoneMotionManager.authorizationStatus() {
+        case .notDetermined:
+            transition(to: .permissionNotDetermined)
+        case .denied, .restricted:
+            transition(to: .permissionDenied)
+        case .authorized:
+            motion.startConnectionStatusUpdates()
+            startSampleStream()
+            // `.connecting` is reserved for the delegate `didConnect` event
+            // (i.e. the brief gap between AirPods physically connecting and
+            // the first sample arriving). Default to `.noAirPods` here and
+            // let real signals; delegate callbacks or sample arrivals;
+            // drive forward transitions. Don't clobber an active state if
+            // bootstrap re-runs (e.g. when the menu is reopened).
+            switch state {
+            case .permissionNotDetermined, .permissionDenied:
+                transition(to: .noAirPods)
+            default:
+                break
+            }
+        @unknown default:
+            transition(to: .permissionDenied)
+        }
+    }
+
+    private func handleStreamCallback(sample: CMDeviceMotion?, error: Error?) {
+        let status = CMHeadphoneMotionManager.authorizationStatus()
+        if status == .denied || status == .restricted {
+            motion.stopDeviceMotionUpdates()
+            transition(to: .permissionDenied)
+            return
+        }
+        if status == .notDetermined {
+            return
+        }
+        // Authorized from here on.
+        motion.startConnectionStatusUpdates()
+        if let sample {
+            ingestSample(sample)
+        } else if error != nil {
+            // No sample yet; assume AirPods aren't actively streaming.
+            // Delegate `didConnect` or a future sample will promote us forward.
+            if state == .permissionNotDetermined || state == .permissionDenied {
+                transition(to: .noAirPods)
+            }
+        }
+    }
+
+    private func startSampleStream() {
+        guard !motion.isDeviceMotionActive else { return }
+        motion.startDeviceMotionUpdates(to: motionQueue) { [weak self] sample, error in
+            guard let self else { return }
+            DispatchQueue.main.async {
+                if let sample {
+                    self.ingestSample(sample)
+                } else if let error {
+                    print("Motion error: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+
+    private func ingestSample(_ sample: CMDeviceMotion) {
+        // Flip state BEFORE writing motion values so observers see .streaming
+        // before any consumer reads the new motion data; preserves the
+        // "isMotionEnabled before first paint" ordering invariant.
+        if state != .streaming {
+            transition(to: .streaming)
+        }
+        motionX = sample.userAcceleration.x
+        motionY = sample.userAcceleration.y
+        resetStaleTimer()
+    }
+
+    private func transition(to next: MotionState) {
+        guard state != next else { return }
+        state = next
+        if next != .streaming {
+            cancelStaleTimer()
+        }
+        if next == .noAirPods || next == .permissionDenied || next == .permissionNotDetermined {
+            motionX = 0
+            motionY = 0
+        }
+    }
+
+    // MARK: - Stale watchdog
+
+    private func resetStaleTimer() {
+        staleTimer?.invalidate()
+        staleTimer = Timer.scheduledTimer(withTimeInterval: staleThreshold, repeats: false) { [weak self] _ in
+            guard let self else { return }
+            if self.state == .streaming {
+                self.transition(to: .stale)
+            }
+        }
+    }
+
+    private func cancelStaleTimer() {
+        staleTimer?.invalidate()
+        staleTimer = nil
+    }
+
+    // MARK: - CMHeadphoneMotionManagerDelegate
+
+    func headphoneMotionManagerDidConnect(_ manager: CMHeadphoneMotionManager) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            guard CMHeadphoneMotionManager.authorizationStatus() == .authorized else { return }
+            if self.state == .noAirPods {
+                self.transition(to: .connecting)
+                self.startSampleStream()
+            }
+        }
+    }
+
+    func headphoneMotionManagerDidDisconnect(_ manager: CMHeadphoneMotionManager) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.motion.stopDeviceMotionUpdates()
+            if CMHeadphoneMotionManager.authorizationStatus() == .authorized {
+                self.transition(to: .noAirPods)
+            }
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -23,9 +23,12 @@
 
 Mac Motion Cues is a macOS app that enables motion cue dots on your screen to help with motion sickness!
 
+> Unlike Apple's built-in Motion Cues, this app also works on **macOS Sequoia (15)** and **M1 MacBooks**. There is no need for the latest hardware or OS.
+
 ## Features
 
 * Add motion cues to your screen based on headphone motion
+* Works on macOS Sequoia (15)+ and Apple Silicon Macs (including M1)
 
 ## Installation
 


### PR DESCRIPTION
## Summary

Expands Mac Motion Cues beyond the original "AirPods + main display" path so it's usable for M1 MacBook owners and anyone on macOS < 26 (where Apple's own Vehicle Motion Cues doesn't exist). The bulk is a reactive rewrite of how motion state, settings, and overlays flow through the app; the new sensor architecture is designed so a future on-board IMU source drops in as a single file.

## Highlights

**Multi-display & multi-Space overlay** (#2, #3) — `OverlayWindowController` spawns one transparent `NSWindow` per `NSScreen`, keyed by `CGDirectDisplayID`, and re-syncs on `didChangeScreenParametersNotification`. Windows join all Spaces (including per-app fullscreen Spaces). Replaces the old hard-coded `NSScreen.main.frame` window that left half the dots off-screen on non-default displays.

**Multi-source motion architecture** — Two protocols: `MotionSource` ("drives the dots") and `VehicleDetectionSource` ("is the user in a vehicle?"). `MotionPipeline` registers sources, persists per-source enable state, picks an active source by priority, and exposes a `shouldRenderCues` predicate the overlay observer reacts to. `AirPodsMotionSource` ports the previous behavior and now also derives `yawRate` from `rotationRate.z` (a direct head-yaw signal vs. integrating noisy lateral accel).

**CoreLocation auto-detect** — Opt-in `CoreLocationDetectionSource` uses `CLLocation.speed` with hysteresis (≥5 m/s for 5s → in-vehicle; ≤1 m/s for 30s → out) to gate cue rendering. Permission is requested only when the user toggles the source on. Adds the location entitlement and `NSLocation*UsageDescription` strings.

**Reactive motion state** — Replaces the `isMotionEnabled` bool that latched true forever with a `MotionState` enum (`permissionNotDetermined / permissionDenied / noAirPods / connecting / streaming / stale`) driven by `CMHeadphoneMotionManagerDelegate` callbacks plus a 5s watchdog. AirPods being removed, sleeping, or unpaired now flows through the UI in under a second.

**Onboarding-aware menu UX** — Settings stay editable regardless of `appEnabled`; the Motion section becomes a status panel that branches on state with inline guidance for each unhappy path (Grant Access, Open System Settings, "put on your AirPods", "AirPods went to sleep"). Overlay mounts at app launch instead of waiting for the menu to be opened.

**Settings persistence** — All visual + motion prefs (`dotSize`, `verticalSpacing`, `motionSensitivity`, `xMotionEnabled`, `dotStyle`, `haloStyle`) now persist via `UserDefaults` through a single `DotsSettings` `@Observable` singleton. Previously four were lost on relaunch and two were declared twice with conflicting `@AppStorage` defaults.

**Declarative settings flow** — Per-window `DotsViewModel`s observe `DotsSettings` via `withObservationTracking` instead of being imperatively pushed at via `notifySettingsChanged()`. The performance constraints (ForEach by indices, no implicit animations, O(n) `updateDotsPosition`) are preserved.

## Polish

- **Menu-bar popover no longer flickers** — extracted the live X/Y readout into a `MotionReadout` leaf so the ~25 Hz `motionX/Y` invalidations don't reflow the entire popover; monospaced digits + fixed-width frame keep the minus sign from shifting siblings.
- **Smooth edge fade** — replaces the binary 150pt cutoff with a linear ramp inset by one dot diameter from each edge, fading over two diameters of travel.
- **Even-column layout** — fixes uneven gaps at the wrap edge (stale precomputed maxY/minY) and left/right column count drift (odd total N split ceil/floor between columns).
- **i18n consolidation** — string catalogs are now the single source of truth for every user-facing string in the app, including the OS Motion & Fitness permission prompt (previously hardcoded English). Adds full **German** localization on top of en + pt-BR.
- **README** — notes Sequoia (15) and M1 compatibility.

Closes #2, #3, #4.
